### PR TITLE
Add set text analyser for matlab lexer

### DIFF
--- a/lexers/m/matlab.go
+++ b/lexers/m/matlab.go
@@ -1,8 +1,16 @@
 package m
 
 import (
+	"regexp"
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	matlabAnalyserCommentRe   = regexp.MustCompile(`^\s*%`)
+	matlabAnalyserSystemCMDRe = regexp.MustCompile(`^!\w+`)
 )
 
 // Matlab lexer.
@@ -48,4 +56,35 @@ var Matlab = internal.Register(MustNewLexer(
 			{`(\s*)([a-zA-Z_]\w*)`, ByGroups(Text, NameFunction), Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	lines := strings.Split(strings.Replace(text, "\r\n", "\n", -1), "\n")
+
+	var firstNonComment string
+	for _, line := range lines {
+		if !matlabAnalyserCommentRe.MatchString(line) {
+			firstNonComment = strings.TrimSpace(line)
+			break
+		}
+	}
+
+	// function declaration
+	if strings.HasPrefix(firstNonComment, "function") && !strings.Contains(firstNonComment, "{") {
+		return 1.0
+	}
+
+	// comment
+	for _, line := range lines {
+		if matlabAnalyserCommentRe.MatchString(line) {
+			return 0.2
+		}
+	}
+
+	// system cmd
+	for _, line := range lines {
+		if matlabAnalyserSystemCMDRe.MatchString(line) {
+			return 0.2
+		}
+	}
+
+	return 0
+}))

--- a/lexers/m/matlab_test.go
+++ b/lexers/m/matlab_test.go
@@ -1,7 +1,7 @@
 package m_test
 
 import (
-	"strings"
+	"io/ioutil"
 	"testing"
 
 	"github.com/alecthomas/assert"
@@ -11,36 +11,23 @@ import (
 
 func TestMatlab_AnalyseText(t *testing.T) {
 	tests := map[string]struct {
-		Text     string
+		Filepath string
 		Expected float32
 	}{
 		"function": {
-			Text: strings.Join([]string{
-				"% comment",
-				"function foo = bar(a, b, c)",
-			}, "\n"),
+			Filepath: "testdata/matlab_function.m",
 			Expected: 1.0,
 		},
 		"comment": {
-			Text: strings.Join([]string{
-				"",
-				"% comment",
-				"",
-			}, "\n"),
+			Filepath: "testdata/matlab_comment.m",
 			Expected: 0.2,
 		},
-		"system cmd": {
-			Text: strings.Join([]string{
-				"",
-				"!rmdir oldtests",
-			}, "\n"),
+		"systemcmd": {
+			Filepath: "testdata/matlab_systemcmd.m",
 			Expected: 0.2,
 		},
 		"windows": {
-			Text: strings.Join([]string{
-				"% comment",
-				"function foo = bar(a, b, c)",
-			}, "\r\n"),
+			Filepath: "testdata/matlab_windows.m",
 			Expected: 1.0,
 		},
 	}
@@ -48,10 +35,13 @@ func TestMatlab_AnalyseText(t *testing.T) {
 	for name, test := range tests {
 		test := test
 		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
 			analyser, ok := m.Matlab.(chroma.Analyser)
 			assert.True(t, ok)
 
-			assert.Equal(t, test.Expected, analyser.AnalyseText(test.Text))
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
 		})
 	}
 }

--- a/lexers/m/matlab_test.go
+++ b/lexers/m/matlab_test.go
@@ -1,0 +1,57 @@
+package m_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/m"
+)
+
+func TestMatlab_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Text     string
+		Expected float32
+	}{
+		"function": {
+			Text: strings.Join([]string{
+				"% comment",
+				"function foo = bar(a, b, c)",
+			}, "\n"),
+			Expected: 1.0,
+		},
+		"comment": {
+			Text: strings.Join([]string{
+				"",
+				"% comment",
+				"",
+			}, "\n"),
+			Expected: 0.2,
+		},
+		"system cmd": {
+			Text: strings.Join([]string{
+				"",
+				"!rmdir oldtests",
+			}, "\n"),
+			Expected: 0.2,
+		},
+		"windows": {
+			Text: strings.Join([]string{
+				"% comment",
+				"function foo = bar(a, b, c)",
+			}, "\r\n"),
+			Expected: 1.0,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			analyser, ok := m.Matlab.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(test.Text))
+		})
+	}
+}

--- a/lexers/m/testdata/matlab_comment.m
+++ b/lexers/m/testdata/matlab_comment.m
@@ -1,0 +1,2 @@
+
+% comment

--- a/lexers/m/testdata/matlab_function.m
+++ b/lexers/m/testdata/matlab_function.m
@@ -1,0 +1,2 @@
+% comment
+function foo = bar(a, b, c)

--- a/lexers/m/testdata/matlab_systemcmd.m
+++ b/lexers/m/testdata/matlab_systemcmd.m
@@ -1,0 +1,3 @@
+
+!rmdir oldtests
+

--- a/lexers/m/testdata/matlab_windows.m
+++ b/lexers/m/testdata/matlab_windows.m
@@ -1,0 +1,2 @@
+% comment
+function foo = bar(a, b, c)


### PR DESCRIPTION
This PR ports pygments matlab text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/matlab.py#L165

Text analysis is used in wakatime client to determine the language of a file, once multiple lexers match the file extension.

