### PR TITLE
Add set text analyzer for actionscript lexer

### DIFF
--- a/lexers/a/actionscript.go
+++ b/lexers/a/actionscript.go
@@ -36,4 +36,9 @@ var Actionscript = internal.Register(MustNewLexer(
 			{`'(\\\\|\\'|[^'])*'`, LiteralStringSingle, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// This is only used to disambiguate between ActionScript and
+	// ActionScript3. We return 0 here; the ActionScript3 lexer will match
+	// AS3 variable definitions and that will hopefully suffice.
+	return 0
+}))

--- a/lexers/a/actionscript3.go
+++ b/lexers/a/actionscript3.go
@@ -1,9 +1,13 @@
 package a
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var actionscript3AnalyserRe = regexp.MustCompile(`\w+\s*:\s*\w`)
 
 // Actionscript 3 lexer.
 var Actionscript3 = internal.Register(MustNewLexer(
@@ -53,4 +57,10 @@ var Actionscript3 = internal.Register(MustNewLexer(
 			Default(Pop(1)),
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if actionscript3AnalyserRe.MatchString(text) {
+		return 0.3
+	}
+
+	return 0
+}))

--- a/lexers/a/actionscript3_test.go
+++ b/lexers/a/actionscript3_test.go
@@ -16,5 +16,5 @@ func TestActionscript3_AnalyseText(t *testing.T) {
 	analyser, ok := a.Actionscript3.(chroma.Analyser)
 	assert.True(t, ok)
 
-	assert.Equal(t, 0.3, analyser.AnalyseText(string(data)))
+	assert.Equal(t, float32(0.3), analyser.AnalyseText(string(data)))
 }

--- a/lexers/a/actionscript3_test.go
+++ b/lexers/a/actionscript3_test.go
@@ -10,11 +10,34 @@ import (
 )
 
 func TestActionscript3_AnalyseText(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/actionscript3.as")
-	assert.NoError(t, err)
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"basic": {
+			Filepath: "testdata/actionscript3.as",
+			Expected: 0.3,
+		},
+		"capital letters": {
+			Filepath: "testdata/actionscript3_capital_letter.as",
+			Expected: 0.3,
+		},
+		"spaces": {
+			Filepath: "testdata/actionscript3_spaces.as",
+			Expected: 0.3,
+		},
+	}
 
-	analyser, ok := a.Actionscript3.(chroma.Analyser)
-	assert.True(t, ok)
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
 
-	assert.Equal(t, float32(0.3), analyser.AnalyseText(string(data)))
+			analyser, ok := a.Actionscript3.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
 }

--- a/lexers/a/actionscript3_test.go
+++ b/lexers/a/actionscript3_test.go
@@ -1,0 +1,20 @@
+package a_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/a"
+)
+
+func TestActionscript3_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/actionscript3.as")
+	assert.NoError(t, err)
+
+	analyser, ok := a.Actionscript3.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, 0.3, analyser.AnalyseText(string(data)))
+}

--- a/lexers/a/testdata/actionscript3.as
+++ b/lexers/a/testdata/actionscript3.as
@@ -1,0 +1,1 @@
+var circle:Sprite = new Sprite();

--- a/lexers/a/testdata/actionscript3_capital_letter.as
+++ b/lexers/a/testdata/actionscript3_capital_letter.as
@@ -1,0 +1,1 @@
+var CIRCLE:Sprite = new Sprite();

--- a/lexers/a/testdata/actionscript3_spaces.as
+++ b/lexers/a/testdata/actionscript3_spaces.as
@@ -1,0 +1,1 @@
+var circle: Sprite = new Sprite();


### PR DESCRIPTION
This PR ports pygments actionscript and actionscript3 text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/actionscript.py#L198

https://github.com/wakatime/wakatime-cli/issues/82