### PR TITLE
Add set text analyser for qbasic lexer

### DIFF
--- a/lexers/q/qbasic.go
+++ b/lexers/q/qbasic.go
@@ -1,6 +1,8 @@
 package q
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -64,4 +66,10 @@ var Qbasic = internal.Register(MustNewLexer(
 			{`\b(ACCESS|ALIAS|ANY|APPEND|AS|BASE|BINARY|BYVAL|CASE|CDECL|DOUBLE|ELSE|ELSEIF|ENDIF|INTEGER|IS|LIST|LOCAL|LONG|LOOP|MOD|NEXT|OFF|ON|OUTPUT|RANDOM|SIGNAL|SINGLE|STEP|STRING|THEN|TO|UNTIL|USING|WEND)\b`, Keyword, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, "$DYNAMIC") || strings.Contains(text, "$STATIC") {
+		return 0.9
+	}
+
+	return 0
+}))

--- a/lexers/q/qbasic_test.go
+++ b/lexers/q/qbasic_test.go
@@ -1,0 +1,39 @@
+package q_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/q"
+)
+
+func TestQBasic_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"dynamic_cmd": {
+			Filepath: "testdata/qbasic_dynamiccmd.bas",
+			Expected: 0.9,
+		},
+		"static_cmd": {
+			Filepath: "testdata/qbasic_staticcmd.bas",
+			Expected: 0.9,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := q.Qbasic.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/q/testdata/qbasic_dynamiccmd.bas
+++ b/lexers/q/testdata/qbasic_dynamiccmd.bas
@@ -1,0 +1,2 @@
+REM $DYNAMIC             'create dynamic arrays only
+DIM array(10)            'create array with 11 elements

--- a/lexers/q/testdata/qbasic_staticcmd.bas
+++ b/lexers/q/testdata/qbasic_staticcmd.bas
@@ -1,0 +1,4 @@
+REM $STATIC
+
+INPUT "Enter array size: ", size
+DIM array(size)   'using an actual number instead of the variable will create an error!


### PR DESCRIPTION
This PR ports pygments QBasic text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/basic.py#L500

https://github.com/wakatime/wakatime-cli/issues/83