### PR TITLE
Add set text analyser for C lexer

### DIFF
--- a/lexers/c/c.go
+++ b/lexers/c/c.go
@@ -1,8 +1,15 @@
 package c
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	cAnalyserIncludeRe = regexp.MustCompile(`(?m)^\s*#include [<"]`)
+	cAnalyserIfdefRe   = regexp.MustCompile(`(?m)^\s*#ifn?def `)
 )
 
 // C lexer.
@@ -88,4 +95,14 @@ var C = internal.Register(MustNewLexer(
 			{`.*?\n`, Comment, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if cAnalyserIncludeRe.MatchString(text) {
+		return 0.1
+	}
+
+	if cAnalyserIfdefRe.MatchString(text) {
+		return 0.1
+	}
+
+	return 0
+}))

--- a/lexers/c/c_test.go
+++ b/lexers/c/c_test.go
@@ -1,0 +1,43 @@
+package c_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestC_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"include": {
+			Filepath: "testdata/c_include.c",
+			Expected: 0.1,
+		},
+		"ifdef": {
+			Filepath: "testdata/c_ifdef.c",
+			Expected: 0.1,
+		},
+		"ifndef": {
+			Filepath: "testdata/c_ifndef.c",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := c.C.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/c/testdata/c_ifdef.c
+++ b/lexers/c/testdata/c_ifdef.c
@@ -1,0 +1,2 @@
+
+#ifdef DEBUG

--- a/lexers/c/testdata/c_ifndef.c
+++ b/lexers/c/testdata/c_ifndef.c
@@ -1,0 +1,2 @@
+
+#ifndef DEBUG

--- a/lexers/c/testdata/c_include.c
+++ b/lexers/c/testdata/c_include.c
@@ -1,0 +1,2 @@
+
+#include <stdio.h>


### PR DESCRIPTION
This PR ports pygments C text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/c_cpp.py#L260

wakatime/wakatime-cli#84