### PR TITLE
Add set text analyser for C++ lexer

### DIFF
--- a/lexers/c/cpp.go
+++ b/lexers/c/cpp.go
@@ -1,8 +1,15 @@
 package c
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	cppAnalyserIncludeRe   = regexp.MustCompile(`#include <[a-z_]+>`)
+	cppAnalyserNamespaceRe = regexp.MustCompile(`using namespace `)
 )
 
 // CPP lexer.
@@ -103,4 +110,14 @@ var CPP = internal.Register(MustNewLexer(
 			{`.*?\n`, Comment, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if cppAnalyserIncludeRe.MatchString(text) {
+		return 0.2
+	}
+
+	if cppAnalyserNamespaceRe.MatchString(text) {
+		return 0.4
+	}
+
+	return 0
+}))

--- a/lexers/c/cpp_test.go
+++ b/lexers/c/cpp_test.go
@@ -1,13 +1,42 @@
 package c_test
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/alecthomas/assert"
-
 	"github.com/alecthomas/chroma"
 	"github.com/alecthomas/chroma/lexers/c"
 )
+
+func TestCpp_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"include": {
+			Filepath: "testdata/cpp_include.cpp",
+			Expected: 0.2,
+		},
+		"namespace": {
+			Filepath: "testdata/cpp_namespace.cpp",
+			Expected: 0.4,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := c.CPP.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}
 
 func TestIssue290(t *testing.T) {
 	input := `// 64-bit floats have 53 digits of precision, including the whole-number-part.

--- a/lexers/c/testdata/cpp_include.cpp
+++ b/lexers/c/testdata/cpp_include.cpp
@@ -1,0 +1,1 @@
+#include <iostream>

--- a/lexers/c/testdata/cpp_namespace.cpp
+++ b/lexers/c/testdata/cpp_namespace.cpp
@@ -1,0 +1,1 @@
+using namespace std;


### PR DESCRIPTION
This PR ports pygments C++ text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/c_cpp.py#L340

wakatime/wakatime-cli#84