### PR TITLE
Add set text analyser for F# lexer

### DIFF
--- a/lexers/f/fsharp.go
+++ b/lexers/f/fsharp.go
@@ -1,6 +1,8 @@
 package f
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -91,4 +93,18 @@ var Fsharp = internal.Register(MustNewLexer(
 			{`"`, LiteralString, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// F# doesn't have that many unique features -- |> and <| are weak
+	// indicators.
+	var result float32 = 0
+
+	if strings.Contains(text, "|>") {
+		result += 0.05
+	}
+
+	if strings.Contains(text, "<|") {
+		result += 0.05
+	}
+
+	return result
+}))

--- a/lexers/f/fsharp_test.go
+++ b/lexers/f/fsharp_test.go
@@ -1,0 +1,43 @@
+package f_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/f"
+)
+
+func TestFsharp_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"pipeline operator": {
+			Filepath: "testdata/fsharp_pipeline_operator.fs",
+			Expected: 0.1,
+		},
+		"forward pipeline operator": {
+			Filepath: "testdata/fsharp_forward_pipeline_operator.fs",
+			Expected: 0.05,
+		},
+		"backward pipeline operator": {
+			Filepath: "testdata/fsharp_backward_pipeline_operator.fs",
+			Expected: 0.05,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := f.Fsharp.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/f/testdata/fsharp_backward_pipeline_operator.fs
+++ b/lexers/f/testdata/fsharp_backward_pipeline_operator.fs
@@ -1,0 +1,1 @@
+let Pipeline1 x = addOne <| timesTwo x

--- a/lexers/f/testdata/fsharp_forward_pipeline_operator.fs
+++ b/lexers/f/testdata/fsharp_forward_pipeline_operator.fs
@@ -1,0 +1,1 @@
+let Pipeline2 x = addOne x |> timesTwo

--- a/lexers/f/testdata/fsharp_pipeline_operator.fs
+++ b/lexers/f/testdata/fsharp_pipeline_operator.fs
@@ -1,0 +1,1 @@
+let Pipeline1 x = addOne <| timesTwo x |> timesThree x


### PR DESCRIPTION
This PR ports pygments F# text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/dotnet.py#L698

wakatime/wakatime-cli#85