### PR TITLE
Add set text analyser for PHP lexer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,6 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sergi/go-diff v1.0.0 // indirect
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 // indirect
 )

--- a/lexers/circular/php.go
+++ b/lexers/circular/php.go
@@ -3,7 +3,11 @@ package circular
 import (
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/shebang"
+	"github.com/dlclark/regexp2"
 )
+
+var phpAnalyserRe = regexp2.MustCompile(`<\?(?!xml)`, regexp2.None)
 
 // PHP lexer for pure PHP code (not embedded in HTML).
 var PHP = internal.Register(MustNewLexer(
@@ -17,7 +21,19 @@ var PHP = internal.Register(MustNewLexer(
 		EnsureNL:        true,
 	},
 	phpCommonRules.Rename("php", "root"),
-))
+).SetAnalyser(func(text string) float32 {
+	matched, _ := shebang.MatchString(text, "php")
+	if matched {
+		return 1.0
+	}
+
+	matched, _ = phpAnalyserRe.MatchString(text)
+	if matched {
+		return 0.3
+	}
+
+	return 0
+}))
 
 var phpCommonRules = Rules{
 	"php": {

--- a/lexers/circular/php_test.go
+++ b/lexers/circular/php_test.go
@@ -1,0 +1,39 @@
+package circular_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/circular"
+)
+
+func TestPhp_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"shebang": {
+			Filepath: "testdata/php_shebang.php",
+			Expected: 1.0,
+		},
+		"basic": {
+			Filepath: "testdata/php_basic.php",
+			Expected: 0.3,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := circular.PHP.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/circular/testdata/php_basic.php
+++ b/lexers/circular/testdata/php_basic.php
@@ -1,0 +1,1 @@
+<?php echo '<p>Hello World</p>'; ?> 

--- a/lexers/circular/testdata/php_shebang.php
+++ b/lexers/circular/testdata/php_shebang.php
@@ -1,0 +1,1 @@
+#!/usr/bin/env php

--- a/pkg/shebang/shebang.go
+++ b/pkg/shebang/shebang.go
@@ -1,0 +1,42 @@
+package shebang
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	splitPathRe    = regexp.MustCompile(`[/\\ ]`)
+	shebangPattern = `(?i)^%s(\.(exe|cmd|bat|bin))?$`
+)
+
+// MatchString check if the given regular expression matches the last part of the
+// shebang if one exists.
+func MatchString(text string, pattern string) (bool, error) {
+	firstLine := strings.ToLower(strings.Split(text, "\n")[0])
+	if !strings.HasPrefix(firstLine, "#!") {
+		return false, nil
+	}
+
+	var parts []string
+
+	for _, line := range splitPathRe.Split(strings.TrimSpace(firstLine[2:]), -1) {
+		if line != "" && !strings.HasPrefix(line, "-") {
+			parts = append(parts, line)
+		}
+	}
+
+	if len(parts) == 0 {
+		return false, nil
+	}
+
+	lastPart := parts[len(parts)-1]
+
+	shebangRe, err := regexp.Compile(fmt.Sprintf(shebangPattern, pattern))
+	if err != nil {
+		return false, fmt.Errorf("failed to compile shebang regex: %s", err)
+	}
+
+	return shebangRe.MatchString(lastPart), nil
+}

--- a/pkg/shebang/shebang_test.go
+++ b/pkg/shebang/shebang_test.go
@@ -1,0 +1,63 @@
+package shebang_test
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma/pkg/shebang"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShebang_MatchString(t *testing.T) {
+	tests := map[string]struct {
+		Text     string
+		Pattern  string
+		Expected bool
+	}{
+		"with break line": {
+			Text:     "#!/usr/bin/env python\n",
+			Pattern:  `python(2\.\d)?`,
+			Expected: true,
+		},
+		"full match": {
+			Text:     "#!/usr/bin/python2.4",
+			Pattern:  `python(2\.\d)?`,
+			Expected: true,
+		},
+		"start something with": {
+			Text:     "#!/usr/bin/startsomethingwith python",
+			Pattern:  `python(2\.\d)?`,
+			Expected: true,
+		},
+		"windows path": {
+			Text:     "#!C:\\Python2.4\\Python.exe",
+			Pattern:  `python(2\.\d)?`,
+			Expected: true,
+		},
+		"path with dash": {
+			Text:     "#!/usr/bin/python-ruby",
+			Pattern:  `python(2\.\d)?`,
+			Expected: false,
+		},
+		"path with slash": {
+			Text:     "#!/usr/bin/python/ruby",
+			Pattern:  `python(2\.\d)?`,
+			Expected: false,
+		},
+		"only shebang": {
+			Text:     "#!",
+			Pattern:  `python`,
+			Expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			res, err := shebang.MatchString(test.Text, test.Pattern)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expected, res)
+		})
+	}
+}


### PR DESCRIPTION
This PR ports pygments PHP text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/php.py#L315

It also creates a new structure called `pkg\shebang` to hold **shebang_matches** from `pygments/util.py`.

Fixes: wakatime/wakatime-cli#87