### PR TITLE
Add set text analyser for Mason lexer

### DIFF
--- a/lexers/m/mason.go
+++ b/lexers/m/mason.go
@@ -1,10 +1,17 @@
 package m
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma"          // nolint
 	. "github.com/alecthomas/chroma/lexers/h" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 	. "github.com/alecthomas/chroma/lexers/p" // nolint
+)
+
+var (
+	masonAnalyserUnnamedBlockRe     = regexp.MustCompile(`</%(class|doc|init)>`)
+	masonAnalyzerCallingComponentRe = regexp.MustCompile(`(?s)<&.+&>`)
 )
 
 // Mason lexer.
@@ -40,4 +47,14 @@ var Mason = internal.Register(MustNewLexer(
                  )`, ByGroups(Using(HTML), Operator), nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if masonAnalyserUnnamedBlockRe.MatchString(text) {
+		return 1.0
+	}
+
+	if masonAnalyzerCallingComponentRe.MatchString(text) {
+		return 0.11
+	}
+
+	return 0
+}))

--- a/lexers/m/mason_test.go
+++ b/lexers/m/mason_test.go
@@ -1,0 +1,39 @@
+package m_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/m"
+)
+
+func TestMason_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"unnamed block": {
+			Filepath: "testdata/mason_unnamed_block.m",
+			Expected: 1.0,
+		},
+		"calling component": {
+			Filepath: "testdata/mason_calling_component.m",
+			Expected: 0.11,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := m.Mason.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/m/testdata/mason_calling_component.m
+++ b/lexers/m/testdata/mason_calling_component.m
@@ -1,0 +1,4 @@
+<& 
+    /path/to/comp.mi, 
+    name=>value 
+&>

--- a/lexers/m/testdata/mason_unnamed_block.m
+++ b/lexers/m/testdata/mason_unnamed_block.m
@@ -1,0 +1,5 @@
+<%class>
+has 'foo';
+has 'bar' => (required => 1);
+has 'baz' => (isa => 'Int', default => 17);
+</%class>


### PR DESCRIPTION
This PR ports pygments Mason text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/templates.py#L566

The regex for `unnamed blocks` seems to be wrong defined in Pygments. According to the [official documentation](https://metacpan.org/pod/distribution/Mason/lib/Mason/Manual/Syntax.pod#%3C%class%3E) a `class` block must be ended  by a `</%class>` and not by `</%class%>`.

Example here:
https://metacpan.org/pod/distribution/Mason/lib/Mason/Manual/Intro.pod#Email-generator-(from-script)

Fixes: wakatime/wakatime-cli#88