### PR TITLE
Add set text analyser for Octave lexer

### DIFF
--- a/lexers/o/octave.go
+++ b/lexers/o/octave.go
@@ -43,4 +43,7 @@ var Octave = internal.Register(MustNewLexer(
 			{`(\s*)([a-zA-Z_]\w*)`, ByGroups(Text, NameFunction), Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Octave is quite hard to spot, and it looks like Matlab as well.
+	return 0
+}))


### PR DESCRIPTION
This PR ports pygments Octave text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/matlab.py#L650

Fixes: wakatime/wakatime-cli#88