### PR TITLE
Add set text analyser for GAS lexer

### DIFF
--- a/lexers/g/gas.go
+++ b/lexers/g/gas.go
@@ -1,8 +1,15 @@
 package g
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	gasAnalyzerDirectiveRe      = regexp.MustCompile(`(?m)^\.(text|data|section)`)
+	gasAnalyzerOtherDirectiveRe = regexp.MustCompile(`(?m)^\.\w+`)
 )
 
 // Gas lexer.
@@ -52,4 +59,14 @@ var Gas = internal.Register(MustNewLexer(
 			{`[-*,.()\[\]!:]+`, Punctuation, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if gasAnalyzerDirectiveRe.MatchString(text) {
+		return 1.0
+	}
+
+	if gasAnalyzerOtherDirectiveRe.MatchString(text) {
+		return 0.1
+	}
+
+	return 0
+}))

--- a/lexers/g/gas_test.go
+++ b/lexers/g/gas_test.go
@@ -1,0 +1,39 @@
+package g_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/g"
+)
+
+func TestGas_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"data directive": {
+			Filepath: "testdata/gas_data_directive.S",
+			Expected: 1.0,
+		},
+		"other directive": {
+			Filepath: "testdata/gas_other_directive.S",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := g.Gas.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/g/testdata/gas_data_directive.S
+++ b/lexers/g/testdata/gas_data_directive.S
@@ -1,0 +1,5 @@
+.data
+count:  .quad   0
+sum:    .quad   0
+format: .asciz  "%g\n"
+error:  .asciz  "There are no command line arguments to average\n"

--- a/lexers/g/testdata/gas_other_directive.S
+++ b/lexers/g/testdata/gas_other_directive.S
@@ -1,0 +1,2 @@
+message:
+.ascii  "Hello, world\n"


### PR DESCRIPTION
This PR ports pygments GAS text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/asm.py#L103

Fixes: wakatime/wakatime-cli#90