### PR TITLE
Add lexer TODO list

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -1,0 +1,109 @@
+## Wakatime lexer support
+
+For the following lexers, text analysis capabilities of pygments have to be ported to chroma for the wakatime golang client to work. In general we focus on lexers, which are associated with the same file extension. If the lexer doesn't even exist in chroma yet, it has to be added.
+
+## Top languages
+
+| file extension | lexer          | done               |
+| ---            | ---            | ---                |
+| `*.as`         | ActionScript   | :heavy_check_mark: |
+|                | ActionScript 3 | :heavy_check_mark: |
+| `*.asm`        | NASM           |                    |
+|                | TASM           |                    |
+| `*.bas`        | QBasic         | :heavy_check_mark: |
+|                | VB.net         | :heavy_check_mark: |
+| `*.c`          | C              | :heavy_check_mark: |
+|                | C++            | :heavy_check_mark: |
+| `*.fs`         | Forth          | :heavy_check_mark: |
+|                | FSharp         | :heavy_check_mark: |
+| `*.h`          | C              | :heavy_check_mark: |
+|                | C++            | :heavy_check_mark: |
+|                | Objective-C    | :heavy_check_mark: |
+| `*.inc`        | POVRay         | :heavy_check_mark: |
+|                | PHP            | :heavy_check_mark: |
+| `*.m`          | Mason          | :heavy_check_mark: |
+|                | Matlab         | :heavy_check_mark: |
+|                | Objective-C    | :heavy_check_mark: |
+|                | Octave         | :heavy_check_mark: |
+| `*.mc`         | Mason          | :heavy_check_mark: |
+|                | MonkeyC        |                    |
+| `*.pl`         | Perl           |                    |
+|                | Prolog         |                    |
+| `*.s`          | GAS            | :heavy_check_mark: |
+|                | R              | :heavy_check_mark: |
+| `*.sql`        | MySQL          |                    |
+|                | SQL            |                    |
+| `*.ts`         | TypeScript     |                    |
+|                | TypoScript     |                    |
+| `*.v`          | Coq            |                    |
+|                | verilog        |                    |
+| `*.xslt`       | HTML           |                    |
+|                | XML            |                    |
+
+## Long tail languages
+
+| file extension(s)                                    | lexer            | lexer exists | note                                | done               |
+| ---                                                  | ---              | ---          | ---                                 | ---                |
+| `*.asax`,`*.ascx`,`*.ashx`,`*.asmx`,`*.aspx`,`*.axd` | aspx-cs          | :x:          |                                     |                    |
+|                                                      | aspx-vb          | :x:          |                                     |                    |
+| `*.ASM`                                              | NASM             |              |                                     |                    |
+|                                                      | TASM             |              |                                     |                    |
+| `*.S`                                                | GAS              |              |                                     |                    |
+|                                                      | S                | :x:          |                                     |                    |
+| `*.b`                                                | Brainfuck        |              |                                     |                    |
+|                                                      | Limbo            | :x:          |                                     |                    |
+| `*.bas`                                              | CBM BASIC V2     | :x:          |                                     |                    |
+|                                                      | QBasic           |              |                                     |                    |
+|                                                      | VB.net           |              |                                     |                    |
+| `*.bug`                                              | BUGS             | :x:          |                                     |                    |
+|                                                      | JAGS             | :x:          |                                     |                    |
+| `*.def`                                              | Modula-2         |              |                                     |                    |
+|                                                      | Singularity      | :x:          |                                     |                    |
+| `*.ecl`                                              | ECL              | :x:          |                                     |                    |
+|                                                      | Prolog           |              |                                     |                    |
+| `*.gd`                                               | GAP              | :x:          |                                     |                    |
+|                                                      | GDScript         |              |                                     |                    |
+| `*.hy`                                               | Hy               |              |                                     |                    |
+|                                                      | Hybris           | :x:          |                                     |                    |
+| `*.inc`                                              | Pawn             | :x:          |                                     |                    |
+|                                                      | PHP              |              |                                     |                    |
+|                                                      | POVRay           |              |                                     |                    |
+| `*.inf`                                              | Inform 6         | :x:          |                                     |                    |
+|                                                      | INI              |              |                                     |                    |
+| `*.j`                                                | Jasmin           | :x:          |                                     |                    |
+|                                                      | Objective-J      |              |                                     |                    |
+| `*.n`                                                | Ezhil            | :x:          |                                     |                    |
+|                                                      | Nemerle          | :x:          |                                     |                    |
+| `*.p`                                                | OpenEdge ABL     | :x:          |                                     |                    |
+|                                                      | Pawn             | :x:          |                                     |                    |
+| `*.pl`                                               | Perl6            | :x:          |                                     |                    |
+|                                                      | Perl             |              |                                     |                    |
+|                                                      | Prolog           |              |                                     |                    |
+| `*.pm`                                               | Perl6            | :x:          |                                     |                    |
+|                                                      | Perl             |              |                                     |                    |
+| `*.pro`                                              | IDL              | :x:          |                                     |                    |
+|                                                      | Prolog           |              |                                     |                    |
+| `*.s`                                                | ca65 assembler   | :x:          |                                     |                    |
+|                                                      | GAS              |              |                                     |                    |
+| `*.sc`                                               | Python           |              |                                     |                    |
+|                                                      | SuperCollider    | :x:          |                                     |                    |
+| `*.scd`                                              | scdoc            | :x:          |                                     |                    |
+|                                                      | SuperCollider    | :x:          |                                     |                    |
+| `*.sl`                                               | Slash            | :x:          | No text analysis exists in pygments |                    |
+|                                                      | Slurm            | :x:          | No text analysis exists in pygments |                    |
+| `*.sql`                                              | SQL              |              |                                     |                    |
+|                                                      | Transact-SQL     |              |                                     |                    |
+| `*.t`                                                | Perl6            |              |                                     |                    |
+|                                                      | Perl             |              |                                     |                    |
+|                                                      | TADS 3           | :x:          |                                     |                    |
+| `*.ttl`                                              | Tera Term macro  | :x:          |                                     |                    |
+|                                                      | Turtle           |              |                                     |                    |
+| `*.u`                                                | ucode            | :x:          |                                     |                    |
+|                                                      | UrbiScript       | :x:          |                                     |                    |
+| `*.v`                                                | Coq              |              |                                     |                    |
+|                                                      | verilog          |              |                                     |                    |
+| `*.xsl`                                              | XML              |              |                                     |                    |
+|                                                      | XSLT             | :x:          |                                     |                    |
+| `*.xslt`                                             | HTML             |              |                                     |                    |
+|                                                      | XML              |              |                                     |                    |
+|                                                      | XSLT             | :x:          |                                     |                    |


### PR DESCRIPTION
This PR adds a todo list for lexer porting between pygments and chroma. Lexers, which are already ported to chroma are marked with check marks. This way we can keep track of our work on this.