### PR TITLE
Add set text analyser for MySQL lexer

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -33,7 +33,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                | Prolog         | :heavy_check_mark: |
 | `*.s`          | GAS            | :heavy_check_mark: |
 |                | R              | :heavy_check_mark: |
-| `*.sql`        | MySQL          |                    |
+| `*.sql`        | MySQL          | :heavy_check_mark: |
 |                | SQL            | :heavy_check_mark: |
 | `*.ts`         | TypeScript     |                    |
 |                | TypoScript     |                    |

--- a/lexers/m/mysql.go
+++ b/lexers/m/mysql.go
@@ -1,8 +1,15 @@
 package m
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	mysqlAnalyserNameBetweenBacktickRe = regexp.MustCompile("`[a-zA-Z_]\\w*`")
+	mysqlAnalyserNameBetweenBracketRe  = regexp.MustCompile(`\[[a-zA-Z_]\w*\]`)
 )
 
 // MySQL lexer.
@@ -51,4 +58,22 @@ var MySQL = internal.Register(MustNewLexer(
 			{`"`, LiteralStringDouble, Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	nameBetweenBacktickCount := len(mysqlAnalyserNameBetweenBacktickRe.FindAllString(text, -1))
+	nameBetweenBracketCount := len(mysqlAnalyserNameBetweenBracketRe.FindAllString(text, -1))
+
+	var result float32
+
+	// Same logic as above in the TSQL analysis.
+	dialectNameCount := nameBetweenBacktickCount + nameBetweenBracketCount
+	if dialectNameCount >= 1 && nameBetweenBacktickCount >= (2*nameBetweenBracketCount) {
+		// Found at least twice as many `name` as [name].
+		result += 0.5
+	} else if nameBetweenBacktickCount > nameBetweenBracketCount {
+		result += 0.2
+	} else if nameBetweenBacktickCount > 0 {
+		result += 0.1
+	}
+
+	return result
+}))

--- a/lexers/m/mysql_test.go
+++ b/lexers/m/mysql_test.go
@@ -1,0 +1,20 @@
+package m_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/m"
+)
+
+func TestMySQL_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/mysql_backtick.sql")
+	assert.NoError(t, err)
+
+	analyser, ok := m.MySQL.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.5), analyser.AnalyseText(string(data)))
+}

--- a/lexers/m/testdata/mysql_backtick.sql
+++ b/lexers/m/testdata/mysql_backtick.sql
@@ -1,0 +1,1 @@
+CREATE TABLE `my_table` (id INT);


### PR DESCRIPTION
This PR ports pygments MySQL text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/sql.py#L752

The current pygments analysis seems to be wrong according to some reasearch on the documentation and local testing. There's no way to use square brackets to compound MySQL queries. As it's a veredict I removed all the logic comparison between square brackets and backticks. Here's the [PR](https://github.com/pygments/pygments/pull/1593) opened for pygments.

https://stackoverflow.com/a/9719904/833531
https://dev.mysql.com/doc/refman/8.0/en/identifiers.html

Fixes: wakatime/wakatime-cli#91