### PR TITLE
Add set text analyser for SQL lexer

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -32,7 +32,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.s`          | GAS            | :heavy_check_mark: |
 |                | R              | :heavy_check_mark: |
 | `*.sql`        | MySQL          |                    |
-|                | SQL            |                    |
+|                | SQL            | :heavy_check_mark: |
 | `*.ts`         | TypeScript     |                    |
 |                | TypoScript     |                    |
 | `*.v`          | Coq            |                    |

--- a/lexers/s/sql.go
+++ b/lexers/s/sql.go
@@ -46,4 +46,6 @@ var SQL = internal.Register(MustNewLexer(
 			{`"`, LiteralStringDouble, Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	return 0.01
+}))


### PR DESCRIPTION
This PR ports pygments SQL text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/sql.py#L500

Fixes: wakatime/wakatime-cli#91