### PR TITLE
Add set text analyser for Coq lexer

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -35,7 +35,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                | SQL            | :heavy_check_mark: |
 | `*.ts`         | TypeScript     |                    |
 |                | TypoScript     |                    |
-| `*.v`          | Coq            |                    |
+| `*.v`          | Coq            | :heavy_check_mark: |
 |                | verilog        |                    |
 | `*.xslt`       | HTML           |                    |
 |                | XML            |                    |

--- a/lexers/c/coq.go
+++ b/lexers/c/coq.go
@@ -1,9 +1,14 @@
 package c
 
 import (
+	"regexp"
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var coqAnalyzerQedCommandRe = regexp.MustCompile(`[qQ]ed`)
 
 // Coq lexer.
 var Coq = internal.Register(MustNewLexer(
@@ -60,4 +65,11 @@ var Coq = internal.Register(MustNewLexer(
 			Default(Pop(1)),
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if coqAnalyzerQedCommandRe.MatchString(text) &&
+		strings.Contains(text, "tauto") {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/c/coq_test.go
+++ b/lexers/c/coq_test.go
@@ -1,0 +1,20 @@
+package c_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestCoq_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/coq_reserved_keyword.v")
+	assert.NoError(t, err)
+
+	analyser, ok := c.Coq.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/c/testdata/coq_reserved_keyword.v
+++ b/lexers/c/testdata/coq_reserved_keyword.v
@@ -1,0 +1,5 @@
+Theorem demorgan : forall (P Q : Prop),
+  ~(P \/ Q) -> ~P /\ ~Q.
+Proof.
+  tauto.
+Qed.


### PR DESCRIPTION
This PR ports pygments Coq text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/theorem.py#L156

In the current pygments analysis the actual value for completing a proof is `Qed` but also `qed` can appear on it. So I applied a regex to validate it. Also opened a [PR](https://github.com/pygments/pygments/pull/1597) to fix it on Pygments.

https://coq.inria.fr/refman/proof-engine/proof-handling.html?highlight=qed#coq:cmd.qed
https://coq.inria.fr/refman/proof-engine/tactics.html#coq:tacn.tauto

Fixes: wakatime/wakatime-cli#93