### PR TITLE
Add Assembly lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -8,7 +8,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | ---            | ---            | ---                |
 | `*.as`         | ActionScript   | :heavy_check_mark: |
 |                | ActionScript 3 | :heavy_check_mark: |
-| `*.asm`        | NASM           |                    |
+| `*.asm`        | NASM           | :heavy_check_mark: |
 |                | TASM           |                    |
 | `*.bas`        | QBasic         | :heavy_check_mark: |
 |                | VB.net         | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -9,7 +9,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.as`         | ActionScript   | :heavy_check_mark: |
 |                | ActionScript 3 | :heavy_check_mark: |
 | `*.asm`        | NASM           | :heavy_check_mark: |
-|                | TASM           |                    |
+|                | TASM           | :heavy_check_mark: |
 | `*.bas`        | QBasic         | :heavy_check_mark: |
 |                | VB.net         | :heavy_check_mark: |
 | `*.c`          | C              | :heavy_check_mark: |

--- a/lexers/n/nasm.go
+++ b/lexers/n/nasm.go
@@ -1,9 +1,13 @@
 package n
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var nasmAnalyzerRe = regexp.MustCompile(`(?i)PROC`)
 
 // Nasm lexer.
 var Nasm = internal.Register(MustNewLexer(
@@ -56,4 +60,11 @@ var Nasm = internal.Register(MustNewLexer(
 			{`byte|[dq]?word`, KeywordType, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Probably TASM
+	if nasmAnalyzerRe.MatchString(text) {
+		return 0
+	}
+
+	return 0
+}))

--- a/lexers/n/nasm_test.go
+++ b/lexers/n/nasm_test.go
@@ -1,0 +1,20 @@
+package n_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/n"
+)
+
+func TestNasm_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/nasm.asm")
+	assert.NoError(t, err)
+
+	analyser, ok := n.Nasm.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/n/testdata/nasm.asm
+++ b/lexers/n/testdata/nasm.asm
@@ -1,0 +1,15 @@
+.model small
+.stack	100h
+.data
+msg	db "Merry Christmas!",'$'
+.code
+main	proc
+    mov ax, SEG msg
+	mov	ds, ax
+	mov	dx, offset msg
+	mov	ah, 9
+	int	21h
+	mov	ax, 4c00h
+	int	21h
+main	endp
+end	main

--- a/lexers/t/tasm.go
+++ b/lexers/t/tasm.go
@@ -1,9 +1,13 @@
 package t
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var tasmAnalyzerRe = regexp.MustCompile(`(?i)PROC`)
 
 // Tasm lexer.
 var Tasm = internal.Register(MustNewLexer(
@@ -58,4 +62,10 @@ var Tasm = internal.Register(MustNewLexer(
 			{`byte|[dq]?word`, KeywordType, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if tasmAnalyzerRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/t/tasm_test.go
+++ b/lexers/t/tasm_test.go
@@ -1,0 +1,20 @@
+package t_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	lt "github.com/alecthomas/chroma/lexers/t"
+)
+
+func TestTasm_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/tasm.asm")
+	assert.NoError(t, err)
+
+	analyser, ok := lt.Tasm.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/t/testdata/tasm.asm
+++ b/lexers/t/testdata/tasm.asm
@@ -1,0 +1,15 @@
+.model small
+.stack	100h
+.data
+msg	db "Merry Christmas!",'$'
+.code
+main	proc
+    mov ax, SEG msg
+	mov	ds, ax
+	mov	dx, offset msg
+	mov	ah, 9
+	int	21h
+	mov	ax, 4c00h
+	int	21h
+main	endp
+end	main


### PR DESCRIPTION
This PR ports pygments Nasm/Tasm text analysis to chroma/go. Original code can be found at: 
Nasm -> https://github.com/pygments/pygments/blob/master/pygments/lexers/asm.py#L758
Tasm -> https://github.com/pygments/pygments/blob/master/pygments/lexers/asm.py#L857

Even though `NasmLexer` on Go will always return 0 I kept as it is in Pygments.
