### PR TITLE
Add Prolog lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -28,7 +28,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.mc`         | Mason          | :heavy_check_mark: |
 |                | MonkeyC        |                    |
 | `*.pl`         | Perl           |                    |
-|                | Prolog         |                    |
+|                | Prolog         | :heavy_check_mark: |
 | `*.s`          | GAS            | :heavy_check_mark: |
 |                | R              | :heavy_check_mark: |
 | `*.sql`        | MySQL          |                    |

--- a/lexers/p/prolog.go
+++ b/lexers/p/prolog.go
@@ -1,6 +1,8 @@
 package p
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -47,4 +49,10 @@ var Prolog = internal.Register(MustNewLexer(
 			{`[*/]`, CommentMultiline, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, ":-") {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/p/prolog_test.go
+++ b/lexers/p/prolog_test.go
@@ -1,0 +1,20 @@
+package p_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/p"
+)
+
+func TestProlog_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/prolog.ecl")
+	assert.NoError(t, err)
+
+	analyser, ok := p.Prolog.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/p/testdata/prolog.ecl
+++ b/lexers/p/testdata/prolog.ecl
@@ -1,0 +1,6 @@
+%% Sorted is a sorted version of List if Sorted is
+%% a permutation of List (same elements in possibly
+%% different order) and Sorted is sorted (second rule).
+sorted(List, Sorted) :-
+    perm(List, Sorted),
+    sorted(Sorted).


### PR DESCRIPTION
This PR ports pygments Prolog text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/prolog.py#L83