### PR TITLE
Add set text analyser for Perl lexer

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -27,7 +27,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                | Octave         | :heavy_check_mark: |
 | `*.mc`         | Mason          | :heavy_check_mark: |
 |                | MonkeyC        |                    |
-| `*.pl`         | Perl           |                    |
+| `*.pl`         | Perl           | :heavy_check_mark: |
 |                | Prolog         | :heavy_check_mark: |
 | `*.s`          | GAS            | :heavy_check_mark: |
 |                | R              | :heavy_check_mark: |

--- a/lexers/p/perl.go
+++ b/lexers/p/perl.go
@@ -1,9 +1,15 @@
 package p
 
 import (
+	"regexp"
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/shebang"
 )
+
+var perlAnalyzerRe = regexp.MustCompile(`(?:my|our)\s+[$@%(]`)
 
 // Perl lexer.
 var Perl = internal.Register(MustNewLexer(
@@ -135,4 +141,22 @@ var Perl = internal.Register(MustNewLexer(
 			{`.+`, CommentPreproc, Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if matched, _ := shebang.MatchString(text, "perl"); matched {
+		return 1.0
+	}
+
+	var result float32 = 0
+
+	if perlAnalyzerRe.MatchString(text) {
+		result += 0.9
+	}
+
+	if strings.Contains(text, ":=") {
+		// := is not valid Perl, but it appears in unicon, so we should
+		// become less confident if we think we found Perl with :=
+		result /= 2
+	}
+
+	return result
+}))

--- a/lexers/p/perl_test.go
+++ b/lexers/p/perl_test.go
@@ -1,0 +1,43 @@
+package p_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/p"
+)
+
+func TestPerl_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"shebang": {
+			Filepath: "testdata/perl_shebang.pl",
+			Expected: 1.0,
+		},
+		"basic": {
+			Filepath: "testdata/perl_basic.pl",
+			Expected: 0.9,
+		},
+		"unicon": {
+			Filepath: "testdata/perl_unicon_like.pl",
+			Expected: 0.0,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := p.Perl.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/p/testdata/perl_basic.pl
+++ b/lexers/p/testdata/perl_basic.pl
@@ -1,0 +1,1 @@
+my $string = "wakatime-cli"; 

--- a/lexers/p/testdata/perl_shebang.pl
+++ b/lexers/p/testdata/perl_shebang.pl
@@ -1,0 +1,1 @@
+#!/usr/bin/env perl

--- a/lexers/p/testdata/perl_unicon_like.pl
+++ b/lexers/p/testdata/perl_unicon_like.pl
@@ -1,0 +1,2 @@
+while line := read(f) do
+    write(line)


### PR DESCRIPTION
This PR ports pygments Perl text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/perl.py#L208

Unicon documentation https://unicon.sourceforge.io/book/ib.pdf