### PR TITLE
Limbo lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -51,7 +51,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.S`                                                | GAS              |              |                                     |                    |
 |                                                      | S                | :x:          |                                     |                    |
 | `*.b`                                                | Brainfuck        |              |                                     |                    |
-|                                                      | Limbo            | :x:          |                                     |                    |
+|                                                      | Limbo            | :x:          |                                     | :heavy_check_mark: |
 | `*.bas`                                              | CBM BASIC V2     | :x:          |                                     |                    |
 |                                                      | QBasic           |              |                                     |                    |
 |                                                      | VB.net           |              |                                     |                    |

--- a/lexers/l/limbo.go
+++ b/lexers/l/limbo.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Limbo lexer.
+var Limbo = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Limbo",
+		Aliases:   []string{"limbo"},
+		Filenames: []string{"*.b"},
+		MimeTypes: []string{"text/limbo"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/limbo.go
+++ b/lexers/l/limbo.go
@@ -1,9 +1,13 @@
 package l
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var limboAnalyzerRe = regexp.MustCompile(`(?m)^implement \w+;`)
 
 // Limbo lexer.
 var Limbo = internal.Register(MustNewLexer(
@@ -16,4 +20,11 @@ var Limbo = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Any limbo module implements something
+	if limboAnalyzerRe.MatchString(text) {
+		return 0.7
+	}
+
+	return 0
+}))

--- a/lexers/l/limbo_test.go
+++ b/lexers/l/limbo_test.go
@@ -1,0 +1,20 @@
+package l_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/l"
+)
+
+func TestLimbo_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/limbo_basic.b")
+	assert.NoError(t, err)
+
+	analyser, ok := l.Limbo.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.7), analyser.AnalyseText(string(data)))
+}

--- a/lexers/l/testdata/limbo_basic.b
+++ b/lexers/l/testdata/limbo_basic.b
@@ -1,0 +1,35 @@
+implement Values;
+
+include "sys.m";
+include "draw.m";
+
+sys: Sys;
+print, sprint: import sys;
+
+Values: module {
+	init: fn(nil: ref Draw->Context, nil: list of string);
+};
+
+init(nil: ref Draw->Context, nil: list of string) {
+	sys = load Sys Sys->PATH;
+
+	n := 7;
+	b := big 8;
+	f := real 3.2;
+	str := "String!";
+
+	print("%d\n", 0 || 1);
+	print("%d\n", 0 && 1);
+
+	print("%d\n", n / int f);
+	print("%f\n", real n / f);
+	print("%bd\n", b / big 8);
+
+	print("%s\n", str[:len str-1]);
+	print("%s\n", str[2:]);
+
+	print("%s", "inferno " + "os " + sprint("%c", '\n'));
+	print("limbo" + " " + "lang\n");
+
+	exit;
+}


### PR DESCRIPTION
This PR ports pygments Limbo text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/inferno.py#L81