### PR TITLE
Cbmbasicv2 lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -52,7 +52,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | S                | :x:          |                                     |                    |
 | `*.b`                                                | Brainfuck        |              |                                     |                    |
 |                                                      | Limbo            | :x:          |                                     |                    |
-| `*.bas`                                              | CBM BASIC V2     | :x:          |                                     |                    |
+| `*.bas`                                              | CBM BASIC V2     | :x:          |                                     | :heavy_check_mark: |
 |                                                      | QBasic           |              |                                     |                    |
 |                                                      | VB.net           |              |                                     |                    |
 | `*.bug`                                              | BUGS             | :x:          |                                     |                    |

--- a/lexers/c/cbmbasicv2.go
+++ b/lexers/c/cbmbasicv2.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CBM BASIC V2 lexer.
+var CbmBasicV2 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "CBM BASIC V2",
+		Aliases:   []string{"cbmbas"},
+		Filenames: []string{"*.bas"},
+		MimeTypes: []string{},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cbmbasicv2.go
+++ b/lexers/c/cbmbasicv2.go
@@ -1,9 +1,13 @@
 package c
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var cbmBasicV2AnalyserRe = regexp.MustCompile(`^\d+`)
 
 // CBM BASIC V2 lexer.
 var CbmBasicV2 = internal.Register(MustNewLexer(
@@ -16,4 +20,12 @@ var CbmBasicV2 = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// if it starts with a line number, it shouldn't be a "modern" Basic
+	// like VB.net
+	if cbmBasicV2AnalyserRe.MatchString(text) {
+		return 0.2
+	}
+
+	return 0
+}))

--- a/lexers/c/cbmbasicv2_test.go
+++ b/lexers/c/cbmbasicv2_test.go
@@ -1,0 +1,20 @@
+package c_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestCbmBasicV2_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/cbmbasicv2_basic.bas")
+	assert.NoError(t, err)
+
+	analyser, ok := c.CbmBasicV2.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.2), analyser.AnalyseText(string(data)))
+}

--- a/lexers/c/testdata/cbmbasicv2_basic.bas
+++ b/lexers/c/testdata/cbmbasicv2_basic.bas
@@ -1,0 +1,1 @@
+10 PRINT "PART 1"


### PR DESCRIPTION
This PR ports pygments CBM BASIC V2 text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/basic.py#L355

According to documentation and the comment left on pygments if lines are found starting with a number might not be detected as "modern" Basic, like VB.Net. So I changed the regex adding `^` at the very beginning.

Pygments [PR](https://github.com/pygments/pygments/pull/1607) to fix it.