### PR TITLE
Jags lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -56,7 +56,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | QBasic           |              |                                     |                    |
 |                                                      | VB.net           |              |                                     |                    |
 | `*.bug`                                              | BUGS             | :x:          |                                     |                    |
-|                                                      | JAGS             | :x:          |                                     |                    |
+|                                                      | JAGS             | :x:          |                                     | :heavy_check_mark: |
 | `*.def`                                              | Modula-2         |              |                                     |                    |
 |                                                      | Singularity      | :x:          |                                     |                    |
 | `*.ecl`                                              | ECL              | :x:          |                                     |                    |

--- a/lexers/j/jags.go
+++ b/lexers/j/jags.go
@@ -1,8 +1,16 @@
 package j
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	jagsAnalyserModelRe = regexp.MustCompile(`(?m)^\s*model\s*\{`)
+	jagsAnalyserDataRe  = regexp.MustCompile(`(?m)^\s*data\s*\{`)
+	jagsAnalyserVarRe   = regexp.MustCompile(`(?m)^\s*var`)
 )
 
 // JAGS lexer.
@@ -16,4 +24,18 @@ var Jags = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if jagsAnalyserModelRe.MatchString(text) {
+		if jagsAnalyserDataRe.MatchString(text) {
+			return 0.9
+		}
+
+		if jagsAnalyserVarRe.MatchString(text) {
+			return 0.9
+		}
+
+		return 0.3
+	}
+
+	return 0
+}))

--- a/lexers/j/jags.go
+++ b/lexers/j/jags.go
@@ -1,0 +1,19 @@
+package j
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// JAGS lexer.
+var Jags = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "JAGS",
+		Aliases:   []string{"jags"},
+		Filenames: []string{"*.jag", "*.bug"},
+		MimeTypes: []string{},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/j/jags_test.go
+++ b/lexers/j/jags_test.go
@@ -1,0 +1,43 @@
+package j_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/j"
+)
+
+func TestJags_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"model only": {
+			Filepath: "testdata/jags_model.jag",
+			Expected: 0.3,
+		},
+		"model and data": {
+			Filepath: "testdata/jags_data.jag",
+			Expected: 0.9,
+		},
+		"model and var": {
+			Filepath: "testdata/jags_var.jag",
+			Expected: 0.9,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := j.Jags.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/j/testdata/jags_data.jag
+++ b/lexers/j/testdata/jags_data.jag
@@ -1,0 +1,10 @@
+data {
+    D <- dim(Z)
+}
+model {
+    for (i in 1:D[1]) {
+        for (j in 1:D[2]) {
+            Z[i,j] <- dnorm(alpha[i] + beta[j], tau)
+        }
+    }
+}

--- a/lexers/j/testdata/jags_model.jag
+++ b/lexers/j/testdata/jags_model.jag
@@ -1,0 +1,7 @@
+model {
+    for (i in 1:D[1]) {
+        for (j in 1:D[2]) {
+            Z[i,j] <- dnorm(alpha[i] + beta[j], tau)
+        }
+    }
+}

--- a/lexers/j/testdata/jags_var.jag
+++ b/lexers/j/testdata/jags_var.jag
@@ -1,0 +1,9 @@
+var x[N];
+
+model {
+    for (i in 1:D[1]) {
+        for (j in 1:D[2]) {
+            Z[i,j] <- dnorm(alpha[i] + beta[j], tau)
+        }
+    }
+}


### PR DESCRIPTION
This PR ports pygments JAGS text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/modeling.py#L271