### PR TITLE
ECL lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -59,7 +59,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | JAGS             | :x:          |                                     | :heavy_check_mark: |
 | `*.def`                                              | Modula-2         | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Singularity      | :x:          |                                     | :heavy_check_mark: |
-| `*.ecl`                                              | ECL              | :x:          |                                     |                    |
+| `*.ecl`                                              | ECL              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Prolog           |              |                                     |                    |
 | `*.gd`                                               | GAP              | :x:          |                                     |                    |
 |                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/e/ecl.go
+++ b/lexers/e/ecl.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ECL lexer.
+var Ecl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ECL",
+		Aliases:   []string{"ecl"},
+		Filenames: []string{"*.ecl"},
+		MimeTypes: []string{"application/x-ecl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/ecl.go
+++ b/lexers/e/ecl.go
@@ -1,6 +1,8 @@
 package e
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,23 @@ var Ecl = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// This is very difficult to guess relative to other business languages.
+	// -> in conjunction with BEGIN/END seems relatively rare though.
+
+	var result float32 = 0
+
+	if strings.Contains(text, "->") {
+		result += 0.01
+	}
+
+	if strings.Contains(text, "BEGIN") {
+		result += 0.01
+	}
+
+	if strings.Contains(text, "END") {
+		result += 0.01
+	}
+
+	return result
+}))

--- a/lexers/e/ecl_test.go
+++ b/lexers/e/ecl_test.go
@@ -1,0 +1,39 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
+)
+
+func TestEcl_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"basic": {
+			Filepath: "testdata/ecl_basic.ecl",
+			Expected: 0.02,
+		},
+		"pass variable": {
+			Filepath: "testdata/ecl_pass_var.ecl",
+			Expected: 0.01,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := e.Ecl.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/e/testdata/ecl_basic.ecl
+++ b/lexers/e/testdata/ecl_basic.ecl
@@ -1,0 +1,9 @@
+DATA132 ColumnMap(UNICODE str) := BEGINC++
+    size_t pos;
+    unsigned char col = 0;
+    memset(__result, '\0', 132);  // init to no column
+    for(pos=0; pos<132; pos++) {
+      if (pos<lenStr && str[pos] == (UChar)'<') col++;
+      ((unsigned char *)__result)[pos] = col;
+    }
+ENDC++;

--- a/lexers/e/testdata/ecl_pass_var.ecl
+++ b/lexers/e/testdata/ecl_pass_var.ecl
@@ -1,0 +1,1 @@
+STRING  ABC -> size32_t lenAbc, const char * abc;


### PR DESCRIPTION
This PR ports pygments ECL text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/ecl.py#L127

Regarding the tests I only created one single file with `BEGINC++` and `ENDC++` block because I haven't found any reference to only `BEGIN` and `END` and also there's no `<-` reference for it.

https://github.com/hpcc-systems/ecl-samples
https://hpccsystems.com/training/documentation/ecl-language-reference/html