### PR TITLE
Add GDScript lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -62,7 +62,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.ecl`                                              | ECL              | :x:          |                                     |                    |
 |                                                      | Prolog           |              |                                     |                    |
 | `*.gd`                                               | GAP              | :x:          |                                     |                    |
-|                                                      | GDScript         |              |                                     |                    |
+|                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
 | `*.hy`                                               | Hy               |              |                                     |                    |
 |                                                      | Hybris           | :x:          |                                     |                    |
 | `*.inc`                                              | Pawn             | :x:          |                                     |                    |

--- a/lexers/g/gdscript.go
+++ b/lexers/g/gdscript.go
@@ -131,7 +131,7 @@ var GDScript = internal.Register(MustNewLexer(
 		},
 	},
 ).SetAnalyser(func(text string) float32 {
-	var result float32 = 0
+	var result float64
 
 	if gdscriptAnalyserFuncRe.MatchString(text) {
 		result += 0.8
@@ -145,6 +145,5 @@ var GDScript = internal.Register(MustNewLexer(
 		result += 0.2
 	}
 
-	return float32(math.Min(float64(result), float64(1.0)))
-
+	return float32(math.Min(result, float64(1.0)))
 }))

--- a/lexers/g/gdscript.go
+++ b/lexers/g/gdscript.go
@@ -1,8 +1,17 @@
 package g
 
 import (
+	"math"
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	gdscriptAnalyserFuncRe     = regexp.MustCompile(`func (_ready|_init|_input|_process|_unhandled_input)`)
+	gdscriptAnalyserKeywordRe  = regexp.MustCompile(`(extends |class_name |onready |preload|load|setget|func [^_])`)
+	gdscriptAnalyserKeyword2Re = regexp.MustCompile(`(var|const|enum|export|signal|tool)`)
 )
 
 // GDScript lexer.
@@ -121,4 +130,21 @@ var GDScript = internal.Register(MustNewLexer(
 			{`\n`, LiteralStringSingle, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	var result float32 = 0
+
+	if gdscriptAnalyserFuncRe.MatchString(text) {
+		result += 0.8
+	}
+
+	if gdscriptAnalyserKeywordRe.MatchString(text) {
+		result += 0.4
+	}
+
+	if gdscriptAnalyserKeyword2Re.MatchString(text) {
+		result += 0.2
+	}
+
+	return float32(math.Min(float64(result), float64(1.0)))
+
+}))

--- a/lexers/g/gdscript_test.go
+++ b/lexers/g/gdscript_test.go
@@ -1,0 +1,47 @@
+package g_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/g"
+)
+
+func TestGdSript_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"func": {
+			Filepath: "testdata/gdscript_func.gd",
+			Expected: 0.8,
+		},
+		"keyword first group": {
+			Filepath: "testdata/gdscript_keyword.gd",
+			Expected: 0.4,
+		},
+		"keyword second group": {
+			Filepath: "testdata/gdscript_keyword2.gd",
+			Expected: 0.2,
+		},
+		"full": {
+			Filepath: "testdata/gdscript_full.gd",
+			Expected: 1.0,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := g.GDScript.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/g/testdata/gdscript_full.gd
+++ b/lexers/g/testdata/gdscript_full.gd
@@ -1,0 +1,10 @@
+class_name StateMachine
+extends Node
+
+signal state_changed(previous, new)
+
+export var initial_state = NodePath()
+
+func _input(event):
+    if event.is_action_pressed("jump"):
+        jump()

--- a/lexers/g/testdata/gdscript_func.gd
+++ b/lexers/g/testdata/gdscript_func.gd
@@ -1,0 +1,3 @@
+func _input(event):
+    if event.is_action_pressed("jump"):
+        jump()

--- a/lexers/g/testdata/gdscript_keyword.gd
+++ b/lexers/g/testdata/gdscript_keyword.gd
@@ -1,0 +1,1 @@
+class_name StateMachine

--- a/lexers/g/testdata/gdscript_keyword2.gd
+++ b/lexers/g/testdata/gdscript_keyword2.gd
@@ -1,0 +1,1 @@
+signal state_changed(previous, new)


### PR DESCRIPTION
This PR ports pygments GDScript text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/gdscript.py#L329