### PR TITLE
Add Hy lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -63,7 +63,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | Prolog           |              |                                     |                    |
 | `*.gd`                                               | GAP              | :x:          |                                     |                    |
 |                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
-| `*.hy`                                               | Hy               |              |                                     |                    |
+| `*.hy`                                               | Hy               | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Hybris           | :x:          |                                     | :heavy_check_mark: |
 | `*.inc`                                              | Pawn             | :x:          |                                     | :heavy_check_mark: |
 |                                                      | PHP              |              |                                     |                    |

--- a/lexers/h/hy.go
+++ b/lexers/h/hy.go
@@ -1,6 +1,8 @@
 package h
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -48,4 +50,10 @@ var Hy = internal.Register(MustNewLexer(
 			{Words(`(?<!\.)`, `\b`, `ArithmeticError`, `AssertionError`, `AttributeError`, `BaseException`, `DeprecationWarning`, `EOFError`, `EnvironmentError`, `Exception`, `FloatingPointError`, `FutureWarning`, `GeneratorExit`, `IOError`, `ImportError`, `ImportWarning`, `IndentationError`, `IndexError`, `KeyError`, `KeyboardInterrupt`, `LookupError`, `MemoryError`, `NameError`, `NotImplemented`, `NotImplementedError`, `OSError`, `OverflowError`, `OverflowWarning`, `PendingDeprecationWarning`, `ReferenceError`, `RuntimeError`, `RuntimeWarning`, `StandardError`, `StopIteration`, `SyntaxError`, `SyntaxWarning`, `SystemError`, `SystemExit`, `TabError`, `TypeError`, `UnboundLocalError`, `UnicodeDecodeError`, `UnicodeEncodeError`, `UnicodeError`, `UnicodeTranslateError`, `UnicodeWarning`, `UserWarning`, `ValueError`, `VMSError`, `Warning`, `WindowsError`, `ZeroDivisionError`), NameException, nil},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, "(import ") || strings.Contains(text, "(defn ") {
+		return 0.9
+	}
+
+	return 0
+}))

--- a/lexers/h/hy_test.go
+++ b/lexers/h/hy_test.go
@@ -1,0 +1,39 @@
+package h_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/h"
+)
+
+func TestHy_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"import": {
+			Filepath: "testdata/hy_import.hy",
+			Expected: 0.9,
+		},
+		"defn": {
+			Filepath: "testdata/hy_defn.hy",
+			Expected: 0.9,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := h.Hy.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/h/testdata/hy_defn.hy
+++ b/lexers/h/testdata/hy_defn.hy
@@ -1,0 +1,1 @@
+(defn numeric? [x]

--- a/lexers/h/testdata/hy_import.hy
+++ b/lexers/h/testdata/hy_import.hy
@@ -1,0 +1,1 @@
+(import numbers)


### PR DESCRIPTION
This PR ports pygments Hy text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/lisp.py#L454