### PR TITLE
Hybris lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -64,7 +64,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.gd`                                               | GAP              | :x:          |                                     |                    |
 |                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
 | `*.hy`                                               | Hy               |              |                                     |                    |
-|                                                      | Hybris           | :x:          |                                     |                    |
+|                                                      | Hybris           | :x:          |                                     | :heavy_check_mark: |
 | `*.inc`                                              | Pawn             | :x:          |                                     |                    |
 |                                                      | PHP              |              |                                     |                    |
 |                                                      | POVRay           |              |                                     |                    |

--- a/lexers/h/hybris.go
+++ b/lexers/h/hybris.go
@@ -1,0 +1,19 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Hybris lexer.
+var Hybris = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Hybris",
+		Aliases:   []string{"hybris", "hy"},
+		Filenames: []string{"*.hy", "*.hyb"},
+		MimeTypes: []string{"text/x-hybris", "application/x-hybris"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/h/hybris.go
+++ b/lexers/h/hybris.go
@@ -1,9 +1,13 @@
 package h
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var hybrisAnalyserRe = regexp.MustCompile(`\b(?:public|private)\s+method\b`)
 
 // Hybris lexer.
 var Hybris = internal.Register(MustNewLexer(
@@ -16,4 +20,12 @@ var Hybris = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// public method and private method don't seem to be quite common
+	// elsewhere.
+	if hybrisAnalyserRe.MatchString(text) {
+		return 0.01
+	}
+
+	return 0
+}))

--- a/lexers/h/hybris_test.go
+++ b/lexers/h/hybris_test.go
@@ -1,0 +1,39 @@
+package h_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/h"
+)
+
+func TestHybris_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"public method": {
+			Filepath: "testdata/hybris_public.hyb",
+			Expected: 0.01,
+		},
+		"private method": {
+			Filepath: "testdata/hybris_private.hyb",
+			Expected: 0.01,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := h.Hybris.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/h/testdata/hybris_private.hyb
+++ b/lexers/h/testdata/hybris_private.hyb
@@ -1,0 +1,3 @@
+private method isBinary(){
+    return me.mode.find("b") != false;
+}

--- a/lexers/h/testdata/hybris_public.hyb
+++ b/lexers/h/testdata/hybris_public.hyb
@@ -1,0 +1,3 @@
+public method File ( file ){
+    me.file = file;
+}


### PR DESCRIPTION
This PR ports pygments Hybris text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/scripting.py#L947