### PR TITLE
Pawn lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -65,7 +65,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
 | `*.hy`                                               | Hy               |              |                                     |                    |
 |                                                      | Hybris           | :x:          |                                     | :heavy_check_mark: |
-| `*.inc`                                              | Pawn             | :x:          |                                     |                    |
+| `*.inc`                                              | Pawn             | :x:          |                                     | :heavy_check_mark: |
 |                                                      | PHP              |              |                                     |                    |
 |                                                      | POVRay           |              |                                     |                    |
 | `*.inf`                                              | Inform 6         | :x:          |                                     |                    |
@@ -75,7 +75,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.n`                                                | Ezhil            | :x:          |                                     |                    |
 |                                                      | Nemerle          | :x:          |                                     |                    |
 | `*.p`                                                | OpenEdge ABL     | :x:          |                                     |                    |
-|                                                      | Pawn             | :x:          |                                     |                    |
+|                                                      | Pawn             | :x:          |                                     | :heavy_check_mark: |
 | `*.pl`                                               | Perl6            | :x:          |                                     |                    |
 |                                                      | Perl             |              |                                     |                    |
 |                                                      | Prolog           |              |                                     |                    |

--- a/lexers/p/pawn.go
+++ b/lexers/p/pawn.go
@@ -1,6 +1,8 @@
 package p
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,12 @@ var Pawn = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// This is basically C. There is a keyword which doesn't exist in C
+	// though and is nearly unique to this language.
+	if strings.Contains(text, "tagof") {
+		return 0.01
+	}
+
+	return 0
+}))

--- a/lexers/p/pawn.go
+++ b/lexers/p/pawn.go
@@ -1,0 +1,19 @@
+package p
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Pawn lexer.
+var Pawn = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Pawn",
+		Aliases:   []string{"pawn"},
+		Filenames: []string{"*.p", "*.pwn", "*.inc"},
+		MimeTypes: []string{"text/x-pawn"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/p/pawn_test.go
+++ b/lexers/p/pawn_test.go
@@ -1,0 +1,20 @@
+package p_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/p"
+)
+
+func TestPawn_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/pawn_tagof.pwn")
+	assert.NoError(t, err)
+
+	analyser, ok := p.Pawn.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.01), analyser.AnalyseText(string(data)))
+}

--- a/lexers/p/testdata/pawn_tagof.pwn
+++ b/lexers/p/testdata/pawn_tagof.pwn
@@ -1,0 +1,10 @@
+stock Print({_, Float, bool}:arg, arg_tag=tagof(arg))
+{
+    switch(arg_tag)
+    {
+        case (tagof(Float:)):
+            PrintFloat(Float:arg);
+        default:
+            PrintInt(_:arg);
+    }
+}


### PR DESCRIPTION
This PR ports pygments Pawn text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/pawn.py#L201