### PR TITLE
Idl lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -81,7 +81,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | Prolog           |              |                                     |                    |
 | `*.pm`                                               | Perl6            | :x:          |                                     |                    |
 |                                                      | Perl             |              |                                     |                    |
-| `*.pro`                                              | IDL              | :x:          |                                     |                    |
+| `*.pro`                                              | IDL              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Prolog           |              |                                     |                    |
 | `*.s`                                                | ca65 assembler   | :x:          |                                     |                    |
 |                                                      | GAS              |              |                                     |                    |

--- a/lexers/i/idl.go
+++ b/lexers/i/idl.go
@@ -1,12 +1,14 @@
 package i
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
 
 // IDL lexer.
-var Idl = internal.Register(MustNewLexer(
+var IDL = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "IDL",
 		Aliases:   []string{"idl"},
@@ -16,4 +18,17 @@ var Idl = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// endelse seems to be unique to IDL, endswitch is rare at least.
+	var result float32
+
+	if strings.Contains(text, "endelse") {
+		result += 0.2
+	}
+
+	if strings.Contains(text, "endswitch") {
+		result += 0.01
+	}
+
+	return result
+}))

--- a/lexers/i/idl.go
+++ b/lexers/i/idl.go
@@ -1,0 +1,19 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// IDL lexer.
+var Idl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "IDL",
+		Aliases:   []string{"idl"},
+		Filenames: []string{"*.pro"},
+		MimeTypes: []string{"text/idl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/idl_test.go
+++ b/lexers/i/idl_test.go
@@ -1,0 +1,39 @@
+package i_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/i"
+)
+
+func TestIdl_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"endelse": {
+			Filepath: "testdata/idl_endelse.pro",
+			Expected: 0.2,
+		},
+		"endswitch": {
+			Filepath: "testdata/idl_endswitch.pro",
+			Expected: 0.01,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := i.IDL.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/i/testdata/idl_endelse.pro
+++ b/lexers/i/testdata/idl_endelse.pro
@@ -1,0 +1,6 @@
+if (a eq 2) and (b eq 3) then begin
+    print, 'a = ', a
+    print, 'b = ', b
+endif else begin
+    if a ne 2 then print, 'a != 2' else print, 'b != 3'
+endelse

--- a/lexers/i/testdata/idl_endswitch.pro
+++ b/lexers/i/testdata/idl_endswitch.pro
@@ -1,0 +1,11 @@
+pro ex_switch, x
+   switch x of
+      1: print, 'one'
+      2: print, 'two'
+      else: begin
+         print, 'you entered: ', x
+         print, 'please enter a value between 1 and 4'
+         end
+   endswitch
+end
+ex_switch, 2


### PR DESCRIPTION
This PR ports pygments IDL text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/idl.py#L272