### PR TITLE
ca65 lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -83,7 +83,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | Perl             |              |                                     |                    |
 | `*.pro`                                              | IDL              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Prolog           |              |                                     |                    |
-| `*.s`                                                | ca65 assembler   | :x:          |                                     |                    |
+| `*.s`                                                | ca65 assembler   | :x:          |                                     | :heavy_check_mark: |
 |                                                      | GAS              |              |                                     |                    |
 | `*.sc`                                               | Python           |              |                                     |                    |
 |                                                      | SuperCollider    | :x:          |                                     |                    |

--- a/lexers/c/ca65.go
+++ b/lexers/c/ca65.go
@@ -1,9 +1,13 @@
 package c
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var ca65AnalyserCommentRe = regexp.MustCompile(`(?m)^\s*;`)
 
 // Ca65 lexer.
 var Ca65 = internal.Register(MustNewLexer(
@@ -16,4 +20,11 @@ var Ca65 = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// comments in GAS start with "#".
+	if ca65AnalyserCommentRe.MatchString(text) {
+		return 0.9
+	}
+
+	return 0
+}))

--- a/lexers/c/ca65.go
+++ b/lexers/c/ca65.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Ca65 lexer.
+var Ca65 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ca65 assembler",
+		Aliases:   []string{"ca65"},
+		Filenames: []string{"*.s"},
+		MimeTypes: []string{},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/ca65_test.go
+++ b/lexers/c/ca65_test.go
@@ -1,0 +1,20 @@
+package c_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestCa65_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/ca65_comment.s")
+	assert.NoError(t, err)
+
+	analyser, ok := c.Ca65.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.9), analyser.AnalyseText(string(data)))
+}

--- a/lexers/c/testdata/ca65_comment.s
+++ b/lexers/c/testdata/ca65_comment.s
@@ -1,0 +1,2 @@
+
+; this is a comment for ca65 assembler


### PR DESCRIPTION
This PR ports pygments ca65 assembler text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/asm.py#L896