### PR TITLE
Supercollider lexer text analysis

### DIFF
--- a/lexers/s/supercollider.go
+++ b/lexers/s/supercollider.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SuperCollider lexer.
+var SuperCollider = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SuperCollider",
+		Aliases:   []string{"sc", "supercollider"},
+		Filenames: []string{"*.sc", "*.scd"},
+		MimeTypes: []string{"application/supercollider", "text/supercollider"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/supercollider.go
+++ b/lexers/s/supercollider.go
@@ -1,6 +1,8 @@
 package s
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,11 @@ var SuperCollider = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// We're searching for a common function and a unique keyword here.
+	if strings.Contains(text, "SinOsc") || strings.Contains(text, "thisFunctionDef") {
+		return 0.1
+	}
+
+	return 0
+}))

--- a/lexers/s/supercollider_test.go
+++ b/lexers/s/supercollider_test.go
@@ -1,0 +1,39 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestSuperCollider_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"sinosc": {
+			Filepath: "testdata/supercollider_sinosc.sc",
+			Expected: 0.1,
+		},
+		"thisFunctionDef": {
+			Filepath: "testdata/supercollider_thisfunctiondef.sc",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := s.SuperCollider.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/s/testdata/supercollider_sinosc.sc
+++ b/lexers/s/testdata/supercollider_sinosc.sc
@@ -1,0 +1,1 @@
+{ [SinOsc.ar(440, 0, 0.2), SinOsc.ar(442, 0, 0.2)] }.play;

--- a/lexers/s/testdata/supercollider_thisfunctiondef.sc
+++ b/lexers/s/testdata/supercollider_thisfunctiondef.sc
@@ -1,0 +1,1 @@
+[thisFunctionDef.varNames, thisFunctionDef.prototypeFrame[thisFunctionDef.numArgs ..]].flop.flatten;


### PR DESCRIPTION
This PR ports pygments SuperCollider text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/supercollider.py#L92

Couldn't find any real example using `thisFunctionDef` in any documentation nor examples. 