### PR TITLE
Wakatime top languages support

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -1,8 +1,10 @@
-## Wakatime lexer support
+# Wakatime lexer support
+
+## Text analysis
 
 For the following lexers, text analysis capabilities of pygments have to be ported to chroma for the wakatime golang client to work. In general we focus on lexers, which are associated with the same file extension. If the lexer doesn't even exist in chroma yet, it has to be added.
 
-## Top languages
+### Top languages
 
 | file extension | lexer          | done               |
 | ---            | ---            | ---                |
@@ -40,7 +42,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.xslt`       | HTML           | :heavy_check_mark: |
 |                | XML            |                    |
 
-## Long tail languages
+### Long tail languages
 
 | file extension(s)                                    | lexer            | lexer exists | note                                | done               |
 | ---                                                  | ---              | ---          | ---                                 | ---                |
@@ -107,3 +109,67 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.xslt`                                             | HTML             | :x:          |                                     | :heavy_check_mark: |
 |                                                      | XML              |              |                                     |                    |
 |                                                      | XSLT             | :x:          |                                     |                    |
+
+## Missing file extension support
+
+For the following lexers, file extension support has to be added, to match the behaviour of wakatime cli. This mostly matches pygments.
+
+### Top languages
+
+| lexer       | filename pattern                                             | done                                  |
+| ---         | ---                                                          | ---                                   |
+| Elixir      | `.eex`                                                       | :heavy_check_mark:                    |
+| JavaScript  | `*.mjs`                                                      | :heavy_check_mark:                    |
+| JSX         | `*.jsx`                                                      | not needed, as matched by react lexer |
+| Python      | `*.jy`, `*.bzl`, `BUCK`, `BUILD`, `BUILD.bazel`, `WORKSPACE` | :heavy_check_mark:                    |
+| TOML        | `Pipfile`, `poetry.lock`                                     | :heavy_check_mark:                    |
+| Twig        | `*.twig`                                                     | :heavy_check_mark:                    |
+
+### Long tail
+
+TBD
+
+## Missing lexers
+
+The following lexers exist in pygments, but not in chroma. They have to be added to emulate the behaviour of pygments, which is the baseline for the wakatime cli.
+
+Only a very stripped down version is necessary here, though. No token related be functionality is needed and we really only care about 2 things here:
+
+1. The lexer name, should match the pygments lexer name.
+2. Associated file name pattern have to be identical to pygments.
+
+### Top languages
+
+| lexer               | filename pattern                            | not in pygments | done               |
+| ---                 | ---                                         | ---             | ---                |
+| Crontab             | `crontab`                                   | :x:             |                    |
+| Coldfusion HTML     | `.cfm`, `*.cfml`                            |                 |                    |
+| Delphi              | `.pas`, `*.dpr`                             |                 |                    |
+| Gosu                | `*.gs`, `*.gsp`, `*.gst`, `*.gsx`, `*.vark` |                 |                    |
+| Lasso               | `'*.lasso', '*.lasso[89]'`                  |                 |                    |
+| LessCss             | `*.less`                                    |                 |                    |
+| liquid              | `*.liquid`                                  |                 |                    |
+| Marko               | `*.marko`                                   | :x:             |                    |
+| Modelica            | `*.mo`                                      |                 |                    |
+| Mustache            | `*.mustache`                                | :x:             |                    |
+| NewLisp             | `*.lsp`, `*.nl`, `*.kif`                    |                 |                    |
+| Objective-J         | `*.j`                                       |                 |                    |
+| Pawn                | `'*.p`, `*.pwn`, `*.inc`                    |                 |                    |
+| Pug                 | `*.pug`, `*.jade`                           |                 |                    |
+| QML                 | `*.qml`, `*.qbs`                            |                 |                    |
+| RPMSpec             | `*.spec`                                    |                 |                    |
+| Sketch Drawing      | `*.sketch`                                  | :x:             |                    |
+| Slim                | `*.slim`                                    |                 |                    |
+| Smali               | `*.smali`                                   |                 |                    |
+| SourcePawn          | `*.sp`                                      |                 |                    |
+| Sublime Text Config | `*.sublime-settings`                        | :x:             |                    |
+| Svelte              | `*.svelte`                                  | :x:             |                    |
+| SWIG                | `*.swg`, `*.i`                              |                 |                    |
+| VCL                 | `*.vcl`                                     |                 |                    |
+| Velocity            | `*.vm`, `*.fhtml`                           |                 |                    |
+| XAML                | `*.xaml`                                    | :x:             |                    |
+| XSLT                | `*.xsl`, `*.xslt`, `*.xpl` # xpl is XProc   |                 |                    |
+
+### Long tail
+
+TBD

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -142,33 +142,33 @@ Only a very stripped down version is necessary here, though. No token related be
 
 | lexer               | filename pattern                            | not in pygments | done               |
 | ---                 | ---                                         | ---             | ---                |
-| Crontab             | `crontab`                                   | :x:             |                    |
-| Coldfusion HTML     | `.cfm`, `*.cfml`                            |                 |                    |
-| Delphi              | `.pas`, `*.dpr`                             |                 |                    |
-| Gosu                | `*.gs`, `*.gsp`, `*.gst`, `*.gsx`, `*.vark` |                 |                    |
-| Lasso               | `'*.lasso', '*.lasso[89]'`                  |                 |                    |
-| LessCss             | `*.less`                                    |                 |                    |
-| liquid              | `*.liquid`                                  |                 |                    |
-| Marko               | `*.marko`                                   | :x:             |                    |
-| Modelica            | `*.mo`                                      |                 |                    |
-| Mustache            | `*.mustache`                                | :x:             |                    |
-| NewLisp             | `*.lsp`, `*.nl`, `*.kif`                    |                 |                    |
-| Objective-J         | `*.j`                                       |                 |                    |
-| Pawn                | `'*.p`, `*.pwn`, `*.inc`                    |                 |                    |
-| Pug                 | `*.pug`, `*.jade`                           |                 |                    |
-| QML                 | `*.qml`, `*.qbs`                            |                 |                    |
-| RPMSpec             | `*.spec`                                    |                 |                    |
-| Sketch Drawing      | `*.sketch`                                  | :x:             |                    |
-| Slim                | `*.slim`                                    |                 |                    |
-| Smali               | `*.smali`                                   |                 |                    |
-| SourcePawn          | `*.sp`                                      |                 |                    |
-| Sublime Text Config | `*.sublime-settings`                        | :x:             |                    |
-| Svelte              | `*.svelte`                                  | :x:             |                    |
-| SWIG                | `*.swg`, `*.i`                              |                 |                    |
-| VCL                 | `*.vcl`                                     |                 |                    |
-| Velocity            | `*.vm`, `*.fhtml`                           |                 |                    |
-| XAML                | `*.xaml`                                    | :x:             |                    |
-| XSLT                | `*.xsl`, `*.xslt`, `*.xpl` # xpl is XProc   |                 |                    |
+| Crontab             | `crontab`                                   | :x:             | :heavy_check_mark: |
+| Coldfusion HTML     | `.cfm`, `*.cfml`                            |                 | :heavy_check_mark: |
+| Delphi              | `.pas`, `*.dpr`                             |                 | :heavy_check_mark: |
+| Gosu                | `*.gs`, `*.gsp`, `*.gst`, `*.gsx`, `*.vark` |                 | :heavy_check_mark: |
+| Lasso               | `*.lasso`, `*.lasso[89]`                    |                 | :heavy_check_mark: |
+| LessCss             | `*.less`                                    |                 | :heavy_check_mark: |
+| liquid              | `*.liquid`                                  |                 | :heavy_check_mark: |
+| Marko               | `*.marko`                                   | :x:             | :heavy_check_mark: |
+| Modelica            | `*.mo`                                      |                 | :heavy_check_mark: |
+| Mustache            | `*.mustache`                                | :x:             | :heavy_check_mark: |
+| NewLisp             | `*.lsp`, `*.nl`, `*.kif`                    |                 | :heavy_check_mark: |
+| Objective-J         | `*.j`                                       |                 | :heavy_check_mark: |
+| Pawn                | `*.p`, `*.pwn`, `*.inc`                     |                 | :heavy_check_mark: |
+| Pug                 | `*.pug`, `*.jade`                           |                 | :heavy_check_mark: |
+| QML                 | `*.qml`, `*.qbs`                            |                 | :heavy_check_mark: |
+| RPMSpec             | `*.spec`                                    |                 | :heavy_check_mark: |
+| Sketch Drawing      | `*.sketch`                                  | :x:             | :heavy_check_mark: |
+| Slim                | `*.slim`                                    |                 | :heavy_check_mark: |
+| Smali               | `*.smali`                                   |                 | :heavy_check_mark: |
+| SourcePawn          | `*.sp`                                      |                 | :heavy_check_mark: |
+| Sublime Text Config | `*.sublime-settings`                        | :x:             | :heavy_check_mark: |
+| Svelte              | `*.svelte`                                  | :x:             | :heavy_check_mark: |
+| SWIG                | `*.swg`, `*.i`                              |                 | :heavy_check_mark: |
+| VCL                 | `*.vcl`                                     |                 | :heavy_check_mark: |
+| Velocity            | `*.vm`, `*.fhtml`                           |                 | :heavy_check_mark: |
+| XAML                | `*.xaml`                                    | :x:             | :heavy_check_mark: |
+| XSLT                | `*.xsl`, `*.xslt`, `*.xpl` # xpl is XProc   |                 | :heavy_check_mark: |
 
 ### Long tail
 

--- a/lexers/c/coldfusion.go
+++ b/lexers/c/coldfusion.go
@@ -46,3 +46,16 @@ var Cfstatement = internal.Register(MustNewLexer(
 		},
 	},
 ))
+
+// ColdfusionHTML lexer.
+var ColdfusionHTML = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Coldfusion HTML",
+		Aliases:   []string{"cfm"},
+		Filenames: []string{"*.cfm", "*.cfml"},
+		MimeTypes: []string{"application/x-coldfusion"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/crontab.go
+++ b/lexers/c/crontab.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Crontab lexer.
+var Crontab = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Crontab",
+		Aliases:   []string{"crontab"},
+		Filenames: []string{"crontab"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/delphi.go
+++ b/lexers/d/delphi.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Delphi lexer.
+var Delphi = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Delphi",
+		Aliases:   []string{"delphi", "pas", "pascal", "objectpascal"},
+		Filenames: []string{"*.pas", "*.dpr"},
+		MimeTypes: []string{"text/x-pascal"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/elixir.go
+++ b/lexers/e/elixir.go
@@ -10,7 +10,7 @@ var Elixir = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "Elixir",
 		Aliases:   []string{"elixir", "ex", "exs"},
-		Filenames: []string{"*.ex", "*.exs"},
+		Filenames: []string{"*.ex", "*.exs", "*.eex"},
 		MimeTypes: []string{"text/x-elixir"},
 	},
 	Rules{

--- a/lexers/g/gosu.go
+++ b/lexers/g/gosu.go
@@ -17,16 +17,3 @@ var Gosu = internal.Register(MustNewLexer(
 		"root": {},
 	},
 ))
-
-// GosuTemplate lexer.
-var GosuTemplate = internal.Register(MustNewLexer(
-	&Config{
-		Name:      "Gosu Template",
-		Aliases:   []string{"gst"},
-		Filenames: []string{"*.gst"},
-		MimeTypes: []string{"text/x-gosu-template"},
-	},
-	Rules{
-		"root": {},
-	},
-))

--- a/lexers/g/gosu.go
+++ b/lexers/g/gosu.go
@@ -1,0 +1,32 @@
+package g
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Gosu lexer.
+var Gosu = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Gosu",
+		Aliases:   []string{"gosu"},
+		Filenames: []string{"*.gs", "*.gsx", "*.gsp", "*.vark"},
+		MimeTypes: []string{"text/x-gosu"},
+	},
+	Rules{
+		"root": {},
+	},
+))
+
+// GosuTemplate lexer.
+var GosuTemplate = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Gosu Template",
+		Aliases:   []string{"gst"},
+		Filenames: []string{"*.gst"},
+		MimeTypes: []string{"text/x-gosu-template"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/g/gosutemplate.go
+++ b/lexers/g/gosutemplate.go
@@ -1,0 +1,19 @@
+package g
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// GosuTemplate lexer.
+var GosuTemplate = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Gosu Template",
+		Aliases:   []string{"gst"},
+		Filenames: []string{"*.gst"},
+		MimeTypes: []string{"text/x-gosu-template"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/j/javascript.go
+++ b/lexers/j/javascript.go
@@ -65,7 +65,7 @@ var Javascript = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "JavaScript",
 		Aliases:   []string{"js", "javascript"},
-		Filenames: []string{"*.js", "*.jsm"},
+		Filenames: []string{"*.js", "*.jsm", "*.mjs"},
 		MimeTypes: []string{"application/javascript", "application/x-javascript", "text/x-javascript", "text/javascript"},
 		DotAll:    true,
 		EnsureNL:  true,

--- a/lexers/l/lasso.go
+++ b/lexers/l/lasso.go
@@ -1,0 +1,27 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Lasso lexer.
+var Lasso = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "Lasso",
+		Aliases: []string{"lasso", "lassoscript"},
+		Filenames: []string{
+			"*.lasso",
+			"*.lasso[89]",
+		},
+		AliasFilenames: []string{
+			"*.incl",
+			"*.inc",
+			"*.las",
+		},
+		MimeTypes: []string{"text/x-lasso"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/less.go
+++ b/lexers/l/less.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LESS lexer.
+var LESS = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "LessCss",
+		Aliases:   []string{"less"},
+		Filenames: []string{"*.less"},
+		MimeTypes: []string{"text/x-less-css"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/liquid.go
+++ b/lexers/l/liquid.go
@@ -1,0 +1,18 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Liquid lexer.
+var Liquid = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "liquid",
+		Aliases:   []string{"liquid"},
+		Filenames: []string{"*.liquid"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/m/marko.go
+++ b/lexers/m/marko.go
@@ -1,0 +1,19 @@
+package m
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Marko lexer.
+var Marko = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Marko",
+		Aliases:   []string{"marko"},
+		Filenames: []string{"*.marko"},
+		MimeTypes: []string{"text/x-marko"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/m/modelica.go
+++ b/lexers/m/modelica.go
@@ -1,0 +1,19 @@
+package m
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Modelica lexer.
+var Modelica = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Modelica",
+		Aliases:   []string{"modelica"},
+		Filenames: []string{"*.mo"},
+		MimeTypes: []string{"text/x-modelica"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/m/mustache.go
+++ b/lexers/m/mustache.go
@@ -1,0 +1,19 @@
+package m
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Mustache lexer.
+var Mustache = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Mustache",
+		Aliases:   []string{"mustache"},
+		Filenames: []string{"*.mustache"},
+		MimeTypes: []string{"text/x-mustache-template"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/n/newlisp.go
+++ b/lexers/n/newlisp.go
@@ -1,0 +1,19 @@
+package n
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// NewLisp lexer.
+var NewLisp = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "NewLisp",
+		Aliases:   []string{"newlisp"},
+		Filenames: []string{"*.lsp", "*.nl", "*.kif"},
+		MimeTypes: []string{"text/x-newlisp", "application/x-newlisp"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/p/pawn.go
+++ b/lexers/p/pawn.go
@@ -27,3 +27,16 @@ var Pawn = internal.Register(MustNewLexer(
 
 	return 0
 }))
+
+// SourcePawn lexer.
+var SourcePawn = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SourcePawn",
+		Aliases:   []string{"sp"},
+		Filenames: []string{"*.sp"},
+		MimeTypes: []string{"text/x-sourcepawn"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/p/pawn.go
+++ b/lexers/p/pawn.go
@@ -27,16 +27,3 @@ var Pawn = internal.Register(MustNewLexer(
 
 	return 0
 }))
-
-// SourcePawn lexer.
-var SourcePawn = internal.Register(MustNewLexer(
-	&Config{
-		Name:      "SourcePawn",
-		Aliases:   []string{"sp"},
-		Filenames: []string{"*.sp"},
-		MimeTypes: []string{"text/x-sourcepawn"},
-	},
-	Rules{
-		"root": {},
-	},
-))

--- a/lexers/p/pug.go
+++ b/lexers/p/pug.go
@@ -1,0 +1,19 @@
+package p
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Pug lexer.
+var Pug = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Pug",
+		Aliases:   []string{"pug", "jade"},
+		Filenames: []string{"*.pug", "*.jade"},
+		MimeTypes: []string{"text/x-pug", "text/x-jade"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/p/python.go
+++ b/lexers/p/python.go
@@ -8,9 +8,28 @@ import (
 // Python lexer.
 var Python = internal.Register(MustNewLexer(
 	&Config{
-		Name:      "Python",
-		Aliases:   []string{"python", "py", "sage"},
-		Filenames: []string{"*.py", "*.pyw", "*.sc", "SConstruct", "SConscript", "*.tac", "*.sage"},
+		Name:    "Python",
+		Aliases: []string{"python", "py", "sage"},
+		Filenames: []string{
+			"*.py",
+			"*.pyw",
+			// Jython
+			"*.jy",
+			// Sage
+			"*.sage",
+			// SCons
+			"*.sc",
+			"SConstruct",
+			"SConscript",
+			// Skylark/Starlark (used by Bazel, Buck, and Pants)
+			"*.bzl",
+			"BUCK",
+			"BUILD",
+			"BUILD.bazel",
+			"WORKSPACE",
+			// Twisted Application infrastructure
+			"*.tac",
+		},
 		MimeTypes: []string{"text/x-python", "application/x-python"},
 	},
 	Rules{

--- a/lexers/q/qml.go
+++ b/lexers/q/qml.go
@@ -1,0 +1,19 @@
+package q
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// QML lexer.
+var QML = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "QML",
+		Aliases:   []string{"qml", "qbs"},
+		Filenames: []string{"*.qml", "*.qbs"},
+		MimeTypes: []string{"application/x-qml", "application/x-qt.qbs+qml"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rpmspec.go
+++ b/lexers/r/rpmspec.go
@@ -1,0 +1,19 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RPMSpec lexer.
+var RPMSpec = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "RPMSpec",
+		Aliases:   []string{"spec"},
+		Filenames: []string{"*.spec"},
+		MimeTypes: []string{"text/x-rpm-spec"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sketchdrawing.go
+++ b/lexers/s/sketchdrawing.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SketchDrawing lexer.
+var SketchDrawing = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Sketch Drawing",
+		Aliases:   []string{"sketch"},
+		Filenames: []string{"*.sketch"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/slim.go
+++ b/lexers/s/slim.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Slim lexer.
+var Slim = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Slim",
+		Aliases:   []string{"slim"},
+		Filenames: []string{"*.slim"},
+		MimeTypes: []string{"text/x-slim"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/smali.go
+++ b/lexers/s/smali.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Smali lexer.
+var Smali = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Smali",
+		Aliases:   []string{"smali"},
+		Filenames: []string{"*.smali"},
+		MimeTypes: []string{"text/smali"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sourcepawn.go
+++ b/lexers/s/sourcepawn.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SourcePawn lexer.
+var SourcePawn = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SourcePawn",
+		Aliases:   []string{"sp"},
+		Filenames: []string{"*.sp"},
+		MimeTypes: []string{"text/x-sourcepawn"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sublimetextconfig.go
+++ b/lexers/s/sublimetextconfig.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SublimeTextConfig lexer.
+var SublimeTextConfig = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Sublime Text Config",
+		Aliases:   []string{"sublime"},
+		Filenames: []string{"*.sublime-settings"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/svelte.go
+++ b/lexers/s/svelte.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Svelte lexer.
+var Svelte = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Svelte",
+		Aliases:   []string{"svelte"},
+		Filenames: []string{"*.svelte"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/swig.go
+++ b/lexers/s/swig.go
@@ -1,0 +1,21 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SWIG lexer.
+var SWIG = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SWIG",
+		Aliases:   []string{"swig"},
+		Filenames: []string{"*.swg", "*.i"},
+		MimeTypes: []string{"text/swig"},
+		// Lower than C/C++ and Objective C/C++
+		Priority: 0.04,
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/toml.go
+++ b/lexers/t/toml.go
@@ -9,7 +9,7 @@ var TOML = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "TOML",
 		Aliases:   []string{"toml"},
-		Filenames: []string{"*.toml"},
+		Filenames: []string{"*.toml", "Pipfile", "poetry.lock"},
 		MimeTypes: []string{"text/x-toml"},
 	},
 	Rules{

--- a/lexers/t/twig.go
+++ b/lexers/t/twig.go
@@ -10,7 +10,7 @@ var Twig = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "Twig",
 		Aliases:   []string{"twig"},
-		Filenames: []string{},
+		Filenames: []string{"*.twig"},
 		MimeTypes: []string{"application/x-twig"},
 		DotAll:    true,
 	},

--- a/lexers/v/vcl.go
+++ b/lexers/v/vcl.go
@@ -1,0 +1,19 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// VCL lexer.
+var VCL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "VCL",
+		Aliases:   []string{"vcl"},
+		Filenames: []string{"*.vcl"},
+		MimeTypes: []string{"text/x-vclsrc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/v/velocity.go
+++ b/lexers/v/velocity.go
@@ -1,0 +1,18 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Velocity lexer.
+var Velocity = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Velocity",
+		Aliases:   []string{"velocity"},
+		Filenames: []string{"*.vm", "*.fhtml"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/x/xaml.go
+++ b/lexers/x/xaml.go
@@ -1,0 +1,19 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// XAML lexer.
+var XAML = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "XAML",
+		Aliases:   []string{"xaml"},
+		Filenames: []string{"*.xaml"},
+		MimeTypes: []string{"application/xaml+xml"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/x/xslt.go
+++ b/lexers/x/xslt.go
@@ -1,0 +1,20 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// XSLT lexer.
+var XSLT = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "XSLT",
+		Aliases: []string{"xslt"},
+		// xpl is XProc
+		Filenames: []string{"*.xsl", "*.xslt", "*.xpl"},
+		MimeTypes: []string{"application/xsl+xml", "application/xslt+xml"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds support for top languages to chroma, to match behavior of pygments.

- Adds missing file extension support to existing lexers.
- Adds missing lexers if not existing in chroma.
- Does not include tests, as this will be tested in `wakatime-cli` repo. PR will be opened, once this PR is merged. 

Changes are reflected in updated `lexers/TODO.md` document. 