### PR TITLE
Inform6 lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -69,7 +69,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | PHP              |              |                                     |                    |
 |                                                      | POVRay           |              |                                     |                    |
 | `*.inf`                                              | Inform 6         | :x:          |                                     | :heavy_check_mark: |
-|                                                      | INI              |              |                                     | :heavy_check_mark: |
+|                                                      | INI              | :x:          |                                     | :heavy_check_mark: |
 | `*.j`                                                | Jasmin           | :x:          |                                     |                    |
 |                                                      | Objective-J      |              |                                     |                    |
 | `*.n`                                                | Ezhil            | :x:          |                                     |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -68,8 +68,8 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.inc`                                              | Pawn             | :x:          |                                     | :heavy_check_mark: |
 |                                                      | PHP              |              |                                     |                    |
 |                                                      | POVRay           |              |                                     |                    |
-| `*.inf`                                              | Inform 6         | :x:          |                                     |                    |
-|                                                      | INI              | :x:          |                                     | :heavy_check_mark: |
+| `*.inf`                                              | Inform 6         | :x:          |                                     | :heavy_check_mark: |
+|                                                      | INI              |              |                                     | :heavy_check_mark: |
 | `*.j`                                                | Jasmin           | :x:          |                                     |                    |
 |                                                      | Objective-J      |              |                                     |                    |
 | `*.n`                                                | Ezhil            | :x:          |                                     |                    |

--- a/lexers/i/inform6.go
+++ b/lexers/i/inform6.go
@@ -1,9 +1,13 @@
 package i
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var inform6AnalyserRe = regexp.MustCompile(`(?i)\borigsource\b`)
 
 // Inform6 lexer.
 var Inform6 = internal.Register(MustNewLexer(
@@ -15,4 +19,12 @@ var Inform6 = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// We try to find a keyword which seem relatively common, unfortunately
+	// there is a decent overlap with Smalltalk keywords otherwise here.
+	if inform6AnalyserRe.MatchString(text) {
+		return 0.05
+	}
+
+	return 0
+}))

--- a/lexers/i/inform6.go
+++ b/lexers/i/inform6.go
@@ -1,0 +1,18 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Inform6 lexer.
+var Inform6 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Inform 6",
+		Aliases:   []string{"inform6", "i6"},
+		Filenames: []string{"*.inf"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/inform6_test.go
+++ b/lexers/i/inform6_test.go
@@ -1,0 +1,20 @@
+package i_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/i"
+)
+
+func TestInform6_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/inform6_basic.inf")
+	assert.NoError(t, err)
+
+	analyser, ok := i.Inform6.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.05), analyser.AnalyseText(string(data)))
+}

--- a/lexers/i/testdata/inform6_basic.inf
+++ b/lexers/i/testdata/inform6_basic.inf
@@ -1,0 +1,1 @@
+Origsource "^~@{.inf";


### PR DESCRIPTION
This PR ports pygments Inform 6 text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/int_fiction.py#L519