### PR TITLE
Jasmin lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -70,7 +70,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | POVRay           |              |                                     |                    |
 | `*.inf`                                              | Inform 6         | :x:          |                                     | :heavy_check_mark: |
 |                                                      | INI              | :x:          |                                     | :heavy_check_mark: |
-| `*.j`                                                | Jasmin           | :x:          |                                     |                    |
+| `*.j`                                                | Jasmin           | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Objective-J      | :x:          |                                     | :heavy_check_mark: |
 | `*.n`                                                | Ezhil            | :x:          |                                     |                    |
 |                                                      | Nemerle          | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/j/jasmin.go
+++ b/lexers/j/jasmin.go
@@ -1,0 +1,18 @@
+package j
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Jasmin lexer.
+var Jasmin = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Jasmin",
+		Aliases:   []string{"jasmin", "jasminxt"},
+		Filenames: []string{"*.j"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/j/jasmin.go
+++ b/lexers/j/jasmin.go
@@ -1,8 +1,17 @@
 package j
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	jasminAnalyserClassRe       = regexp.MustCompile(`(?m)^\s*\.class\s`)
+	jasminAnalyserInstructionRe = regexp.MustCompile(`(?m)^\s*[a-z]+_[a-z]+\b`)
+	jasminAnalyserKeywordsRe    = regexp.MustCompile(
+		`(?m)^\s*\.(attribute|bytecode|debug|deprecated|enclosing|inner|interface|limit|set|signature|stack)\b`)
 )
 
 // Jasmin lexer.
@@ -15,4 +24,20 @@ var Jasmin = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	var result float32
+
+	if jasminAnalyserClassRe.MatchString(text) {
+		result += 0.5
+
+		if jasminAnalyserInstructionRe.MatchString(text) {
+			result += 0.3
+		}
+	}
+
+	if jasminAnalyserKeywordsRe.MatchString(text) {
+		result += 0.6
+	}
+
+	return result
+}))

--- a/lexers/j/jasmin_test.go
+++ b/lexers/j/jasmin_test.go
@@ -1,0 +1,43 @@
+package j_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/j"
+)
+
+func TestJasmin_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"class": {
+			Filepath: "testdata/jasmin_class.j",
+			Expected: 0.5,
+		},
+		"instruction": {
+			Filepath: "testdata/jasmin_instruction.j",
+			Expected: 0.8,
+		},
+		"keyword": {
+			Filepath: "testdata/jasmin_keyword.j",
+			Expected: 0.6,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := j.Jasmin.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/j/testdata/jasmin_class.j
+++ b/lexers/j/testdata/jasmin_class.j
@@ -1,0 +1,1 @@
+    .class public Calculator

--- a/lexers/j/testdata/jasmin_instruction.j
+++ b/lexers/j/testdata/jasmin_instruction.j
@@ -1,0 +1,3 @@
+    .class public Calculator
+    
+    ldc_w 3.141592654    ; push PI as a double

--- a/lexers/j/testdata/jasmin_keyword.j
+++ b/lexers/j/testdata/jasmin_keyword.j
@@ -1,0 +1,1 @@
+   .limit locals 3


### PR DESCRIPTION
This PR ports pygments Jasmin text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/jvm.py#L1608


Also I found useful to make sure the result never gets higer than 1.0 and added `Min` to it. Also the same implementation has been done for GDScript. I already opned a [PR](https://github.com/pygments/pygments/pull/1619) for Pygments.