### PR TITLE
Objectivej lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -71,7 +71,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.inf`                                              | Inform 6         | :x:          |                                     | :heavy_check_mark: |
 |                                                      | INI              | :x:          |                                     | :heavy_check_mark: |
 | `*.j`                                                | Jasmin           | :x:          |                                     |                    |
-|                                                      | Objective-J      |              |                                     |                    |
+|                                                      | Objective-J      | :x:          |                                     | :heavy_check_mark: |
 | `*.n`                                                | Ezhil            | :x:          |                                     |                    |
 |                                                      | Nemerle          | :x:          |                                     |                    |
 | `*.p`                                                | OpenEdge ABL     | :x:          |                                     |                    |

--- a/lexers/o/objectivej.go
+++ b/lexers/o/objectivej.go
@@ -1,0 +1,19 @@
+package o
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Objective-J lexer.
+var ObjectiveJ = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Objective-J",
+		Aliases:   []string{"objective-j", "objectivej", "obj-j", "objj"},
+		Filenames: []string{"*.j"},
+		MimeTypes: []string{"text/x-objective-j"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/o/objectivej.go
+++ b/lexers/o/objectivej.go
@@ -1,9 +1,13 @@
 package o
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var objectiveJAnalyserImportRe = regexp.MustCompile(`(?m)^\s*@import\s+[<"]`)
 
 // Objective-J lexer.
 var ObjectiveJ = internal.Register(MustNewLexer(
@@ -16,4 +20,11 @@ var ObjectiveJ = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// special directive found in most Objective-J files.
+	if objectiveJAnalyserImportRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/o/objectivej_test.go
+++ b/lexers/o/objectivej_test.go
@@ -1,0 +1,20 @@
+package o_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/o"
+)
+
+func TestObjectiveJ_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/objectivej_import.j")
+	assert.NoError(t, err)
+
+	analyser, ok := o.ObjectiveJ.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/o/testdata/objectivej_import.j
+++ b/lexers/o/testdata/objectivej_import.j
@@ -1,0 +1,1 @@
+@import <Foundation/CPObject.j>


### PR DESCRIPTION
This PR ports pygments Objective-J text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/javascript.py#L1023