### PR TITLE
remove linter from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,3 @@
-# linting
-define get_latest_lint_release
-	curl -s "https://api.github.com/repos/golangci/golangci-lint/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
-endef
-LATEST_LINT_VERSION=$(shell $(call get_latest_lint_release))
-INSTALLED_LINT_VERSION=$(shell golangci-lint --version 2>/dev/null | awk '{print "v"$$4}')
-
 .PHONY: chromad upload all
 
 all: README.md tokentype_string.go
@@ -24,19 +17,6 @@ chromad:
 upload: chromad
 	scp chromad root@swapoff.org: && \
 		ssh root@swapoff.org 'install -m755 ./chromad /srv/http/swapoff.org/bin && service chromad restart'
-
-# install linter
-.PHONY: install-linter
-install-linter:
-ifneq "$(INSTALLED_LINT_VERSION)" "$(LATEST_LINT_VERSION)"
-	@echo "new golangci-lint version found:" $(LATEST_LINT_VERSION)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin latest
-endif
-
-# run static analysis tools, configuration in ./.golangci.yml file
-.PHONY: lint
-lint: install-linter
-	golangci-lint run ./...
 
 .PHONY: test
 test:


### PR DESCRIPTION
This PR simply removes `lint` instruction from Makefile as we've discussed.