### PR TITLE
S lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -49,7 +49,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.ASM`                                              | NASM             |              |                                     |                    |
 |                                                      | TASM             |              |                                     |                    |
 | `*.S`                                                | GAS              |              |                                     |                    |
-|                                                      | S                | :x:          |                                     |                    |
+|                                                      | S                | :x:          |                                     | :heavy_check_mark: |
 | `*.b`                                                | Brainfuck        |              |                                     |                    |
 |                                                      | Limbo            | :x:          |                                     | :heavy_check_mark: |
 | `*.bas`                                              | CBM BASIC V2     | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/s/s.go
+++ b/lexers/s/s.go
@@ -3,7 +3,10 @@ package s
 import (
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/dlclark/regexp2"
 )
+
+var sAnalyserRe = regexp2.MustCompile(`[a-z0-9_\])\s]<-(?!-)`, regexp2.None)
 
 // S lexer.
 var S = internal.Register(MustNewLexer(
@@ -17,4 +20,10 @@ var S = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if matched, _ := sAnalyserRe.MatchString(text); matched {
+		return 0.11
+	}
+
+	return 0
+}))

--- a/lexers/s/s.go
+++ b/lexers/s/s.go
@@ -1,0 +1,20 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// S lexer.
+var S = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "S",
+		Aliases:   []string{"splus", "s", "r"},
+		Filenames: []string{"*.S", "*.R", ".Rhistory", ".Rprofile", ".Renviron"},
+		MimeTypes: []string{"text/S-plus", "text/S", "text/x-r-source", "text/x-r",
+			"text/x-R", "text/x-r-history", "text/x-r-profile"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/s_test.go
+++ b/lexers/s/s_test.go
@@ -1,0 +1,20 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestS_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/s.S")
+	assert.NoError(t, err)
+
+	analyser, ok := s.S.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.11), analyser.AnalyseText(string(data)))
+}

--- a/lexers/s/testdata/s.S
+++ b/lexers/s/testdata/s.S
@@ -1,0 +1,4 @@
+prime <- function(x)
+  {
+    1*(abs(x) < chuber)
+  }


### PR DESCRIPTION
This PR ports pygments S text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/r.py#L150