### PR TITLE
Gap lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -63,7 +63,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | Singularity      | :x:          |                                     | :heavy_check_mark: |
 | `*.ecl`                                              | ECL              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Prolog           | :x:          |                                     | :heavy_check_mark: |
-| `*.gd`                                               | GAP              | :x:          |                                     |                    |
+| `*.gd`                                               | GAP              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
 | `*.hy`                                               | Hy               | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Hybris           | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/g/gap.go
+++ b/lexers/g/gap.go
@@ -1,0 +1,19 @@
+package g
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// GAP lexer.
+var Gap = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "GAP",
+		Aliases:   []string{"gap"},
+		Filenames: []string{"*.g", "*.gd", "*.gi", "*.gap"},
+		MimeTypes: []string{},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/g/gap.go
+++ b/lexers/g/gap.go
@@ -1,8 +1,18 @@
 package g
 
 import (
+	"math"
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	gapAnalyserDeclarationRe = regexp.MustCompile(
+		`(InstallTrueMethod|Declare(Attribute|Category|Filter|Operation|GlobalFunction|Synonym|SynonymAttr|Property))`)
+	gapAnalyserImplementationRe = regexp.MustCompile(
+		`(DeclareRepresentation|Install(GlobalFunction|Method|ImmediateMethod|OtherMethod)|New(Family|Type)|Objectify)`)
 )
 
 // GAP lexer.
@@ -16,4 +26,16 @@ var Gap = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	var result float64
+
+	if gapAnalyserDeclarationRe.MatchString(text) {
+		result += 0.7
+	}
+
+	if gapAnalyserImplementationRe.MatchString(text) {
+		result += 0.7
+	}
+
+	return float32(math.Min(result, float64(1.0)))
+}))

--- a/lexers/g/gap_test.go
+++ b/lexers/g/gap_test.go
@@ -1,0 +1,39 @@
+package g_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/g"
+)
+
+func TestGap_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"declaration": {
+			Filepath: "testdata/gap_declaration.g",
+			Expected: 0.7,
+		},
+		"implementation": {
+			Filepath: "testdata/gap_implementation.g",
+			Expected: 0.7,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := g.Gap.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/g/testdata/gap_declaration.g
+++ b/lexers/g/testdata/gap_declaration.g
@@ -1,0 +1,1 @@
+InstallTrueMethod( IsCommutative, IsGroup and IsCyclic );

--- a/lexers/g/testdata/gap_implementation.g
+++ b/lexers/g/testdata/gap_implementation.g
@@ -1,0 +1,9 @@
+InstallMethod( Iterator,
+    "method for `Integers'",
+    [ IsIntegers ],
+    function( Integers )
+    return Objectify( NewType( IteratorsFamily,
+                                   IsIterator
+                               and IsIntegersIteratorCompRep ),
+                      rec( counter := 0 ) );
+    end );


### PR DESCRIPTION
This PR ports pygments GAP text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/algebra.py#L71