### PR TITLE
Add Transact-SQL lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -94,7 +94,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.sl`                                               | Slash            | :x:          | No text analysis exists in pygments |                    |
 |                                                      | Slurm            | :x:          | No text analysis exists in pygments |                    |
 | `*.sql`                                              | SQL              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Transact-SQL     |              |                                     |                    |
+|                                                      | Transact-SQL     | :x:          |                                     | :heavy_check_mark: |
 | `*.t`                                                | Perl6            |              |                                     |                    |
 |                                                      | Perl             |              |                                     |                    |
 |                                                      | TADS 3           | :x:          |                                     |                    |

--- a/lexers/t/testdata/transactsql_bracket.sql
+++ b/lexers/t/testdata/transactsql_bracket.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM [TableX]
+WHERE [KeyCol] = 124

--- a/lexers/t/testdata/transactsql_declare.sql
+++ b/lexers/t/testdata/transactsql_declare.sql
@@ -1,0 +1,1 @@
+DECLARE @find VARCHAR(30);

--- a/lexers/t/testdata/transactsql_go.sql
+++ b/lexers/t/testdata/transactsql_go.sql
@@ -1,0 +1,2 @@
+DROP TABLE TestTable;
+GO

--- a/lexers/t/testdata/transactsql_variable.sql
+++ b/lexers/t/testdata/transactsql_variable.sql
@@ -1,0 +1,1 @@
+SET @MyCounter = 0;

--- a/lexers/t/transactsql.go
+++ b/lexers/t/transactsql.go
@@ -1,8 +1,18 @@
 package t
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	tSQLAnalyserGoRe                  = regexp.MustCompile(`(?i)\bgo\b`)
+	tSQLAnalyserDeclareRe             = regexp.MustCompile(`(?i)\bdeclare\s+@`)
+	tSQLAnalyserVariableRe            = regexp.MustCompile(`@[a-zA-Z_]\w*\b`)
+	tSQLAnalyserNameBetweenBacktickRe = regexp.MustCompile("`[a-zA-Z_]\\w*`")
+	tSQLAnalyserNameBetweenBracketRe  = regexp.MustCompile(`\[[a-zA-Z_]\w*\]`)
 )
 
 // TransactSQL lexer.
@@ -57,4 +67,37 @@ var TransactSQL = internal.Register(MustNewLexer(
 			{`"`, LiteralStringName, Pop(1)},
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if tSQLAnalyserDeclareRe.MatchString(text) {
+		// Found T-SQL variable declaration.
+		return 1.0
+	}
+
+	nameBetweenBacktickCount := len(tSQLAnalyserNameBetweenBacktickRe.FindAllString(text, -1))
+	nameBetweenBracketCount := len(tSQLAnalyserNameBetweenBracketRe.FindAllString(text, -1))
+
+	var result float32
+
+	// We need to check if there are any names using
+	// backticks or brackets, as otherwise both are 0
+	// and 0 >= 2 * 0, so we would always assume it's true
+	dialectNameCount := nameBetweenBacktickCount + nameBetweenBracketCount
+	if dialectNameCount >= 1 && nameBetweenBracketCount >= (2*nameBetweenBacktickCount) {
+		// Found at least twice as many [name] as `name`.
+		result += 0.5
+	} else if nameBetweenBracketCount > nameBetweenBacktickCount {
+		result += 0.2
+	} else if nameBetweenBracketCount > 0 {
+		result += 0.1
+	}
+
+	if tSQLAnalyserVariableRe.MatchString(text) {
+		result += 0.1
+	}
+
+	if tSQLAnalyserGoRe.MatchString(text) {
+		result += 0.1
+	}
+
+	return result
+}))

--- a/lexers/t/transactsql_test.go
+++ b/lexers/t/transactsql_test.go
@@ -1,0 +1,47 @@
+package t_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	lt "github.com/alecthomas/chroma/lexers/t"
+)
+
+func TestTransactSQL_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"declare": {
+			Filepath: "testdata/transactsql_declare.sql",
+			Expected: 1.0,
+		},
+		"bracket": {
+			Filepath: "testdata/transactsql_bracket.sql",
+			Expected: 0.5,
+		},
+		"variable": {
+			Filepath: "testdata/transactsql_variable.sql",
+			Expected: 0.1,
+		},
+		"go": {
+			Filepath: "testdata/transactsql_go.sql",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := lt.TransactSQL.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}


### PR DESCRIPTION
This PR ports pygments Transact-SQL text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/sql.py#L559