### PR TITLE
Scdoc lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -89,7 +89,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | GAS              | :x:          |                                     | :heavy_check_mark: |
 | `*.sc`                                               | Python           |              |                                     |                    |
 |                                                      | SuperCollider    | :x:          |                                     |                    |
-| `*.scd`                                              | scdoc            | :x:          |                                     |                    |
+| `*.scd`                                              | scdoc            | :x:          |                                     | :heavy_check_mark: |
 |                                                      | SuperCollider    | :x:          |                                     |                    |
 | `*.sl`                                               | Slash            | :x:          | No text analysis exists in pygments |                    |
 |                                                      | Slurm            | :x:          | No text analysis exists in pygments |                    |

--- a/lexers/s/scdoc.go
+++ b/lexers/s/scdoc.go
@@ -1,6 +1,8 @@
 package s
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,18 @@ var Scdoc = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// This is very similar to markdown, save for the escape characters
+	// needed for * and _.
+	var result float32
+
+	if strings.Contains(text, `\*`) {
+		result += 0.01
+	}
+
+	if strings.Contains(text, `\_`) {
+		result += 0.01
+	}
+
+	return result
+}))

--- a/lexers/s/scdoc.go
+++ b/lexers/s/scdoc.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// scdoc lexer.
+var Scdoc = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "scdoc",
+		Aliases:   []string{"scdoc", "scd"},
+		Filenames: []string{"*.scd", "*.scdoc"},
+		MimeTypes: []string{},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/scdoc_test.go
+++ b/lexers/s/scdoc_test.go
@@ -1,0 +1,39 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestScdoc_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"asterisk": {
+			Filepath: "testdata/scdoc_asterisk.scd",
+			Expected: 0.01,
+		},
+		"underscore": {
+			Filepath: "testdata/scdoc_underscore.scd",
+			Expected: 0.01,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := s.Scdoc.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/s/testdata/scdoc_asterisk.scd
+++ b/lexers/s/testdata/scdoc_asterisk.scd
@@ -1,0 +1,1 @@
+\_This formatting\_ will not be interpreted by scdoc.

--- a/lexers/s/testdata/scdoc_underscore.scd
+++ b/lexers/s/testdata/scdoc_underscore.scd
@@ -1,0 +1,1 @@
+\*This formatting\* will not be interpreted by scdoc.


### PR DESCRIPTION
This PR ports pygments scdoc text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/scdoc.py#L72