### PR TITLE
Add Turtle lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -99,7 +99,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | Perl             |              |                                     |                    |
 |                                                      | TADS 3           | :x:          |                                     | :heavy_check_mark: |
 | `*.ttl`                                              | Tera Term macro  | :x:          |                                     |                    |
-|                                                      | Turtle           |              |                                     |                    |
+|                                                      | Turtle           | :x:          |                                     | :heavy_check_mark: |
 | `*.u`                                                | ucode            | :x:          |                                     |                    |
 |                                                      | UrbiScript       | :x:          |                                     |                    |
 | `*.v`                                                | Coq              | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/t/testdata/turtle_basic.ttl
+++ b/lexers/t/testdata/turtle_basic.ttl
@@ -1,0 +1,6 @@
+@base  <http://example.com> .
+@prefix dcterms: <http://purl.org/dc/terms/>. @prefix xs: <http://www.w3.org/2001/XMLSchema> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+PREFIX dc: <http://purl.org/dc/elements/1.1/>  # SPARQL-like syntax is OK
+@prefix : <http://xmlns.com/foaf/0.1/> .  # empty prefix is OK

--- a/lexers/t/turtle.go
+++ b/lexers/t/turtle.go
@@ -1,9 +1,13 @@
 package t
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var turtleAnalyserRe = regexp.MustCompile(`^\s*(@base|BASE|@prefix|PREFIX)`)
 
 // Turtle lexer.
 var Turtle = internal.Register(MustNewLexer(
@@ -64,4 +68,12 @@ var Turtle = internal.Register(MustNewLexer(
 			Default(Pop(2)),
 		},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Turtle and Tera Term macro files share the same file extension
+	// but each has a recognizable and distinct syntax.
+	if turtleAnalyserRe.MatchString(text) {
+		return 0.8
+	}
+
+	return 0
+}))

--- a/lexers/t/turtle_test.go
+++ b/lexers/t/turtle_test.go
@@ -1,0 +1,20 @@
+package t_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	lt "github.com/alecthomas/chroma/lexers/t"
+)
+
+func TestMatlab_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/turtle_basic.ttl")
+	assert.NoError(t, err)
+
+	analyser, ok := lt.Turtle.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.8), analyser.AnalyseText(string(data)))
+}


### PR DESCRIPTION
This PR ports pygments Turtle text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/rdf.py#L314

The loop over some keywords has been replaced by a single regex expression.