### PR TITLE
Ucode lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -100,7 +100,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 |                                                      | TADS 3           | :x:          |                                     | :heavy_check_mark: |
 | `*.ttl`                                              | Tera Term macro  | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Turtle           | :x:          |                                     | :heavy_check_mark: |
-| `*.u`                                                | ucode            | :x:          |                                     |                    |
+| `*.u`                                                | ucode            | :x:          |                                     | :heavy_check_mark: |
 |                                                      | UrbiScript       | :x:          |                                     |                    |
 | `*.v`                                                | Coq              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | verilog          | :x:          |                                     | :heavy_check_mark: |

--- a/lexers/u/testdata/ucode_endrepeat.u
+++ b/lexers/u/testdata/ucode_endrepeat.u
@@ -1,0 +1,4 @@
+repeat {
+    write(i)
+}
+endrepeat

--- a/lexers/u/testdata/ucode_endsuspend.u
+++ b/lexers/u/testdata/ucode_endsuspend.u
@@ -1,0 +1,2 @@
+suspend |writes(" e1")\3 do writes(" e2")
+endsuspend

--- a/lexers/u/testdata/ucode_procedure.u
+++ b/lexers/u/testdata/ucode_procedure.u
@@ -1,0 +1,3 @@
+procedure main()
+write("hello, world")
+end

--- a/lexers/u/testdata/ucode_self.u
+++ b/lexers/u/testdata/ucode_self.u
@@ -1,0 +1,1 @@
+\self /self

--- a/lexers/u/testdata/ucode_varset.u
+++ b/lexers/u/testdata/ucode_varset.u
@@ -1,0 +1,1 @@
+x := "Example"

--- a/lexers/u/ucode.go
+++ b/lexers/u/ucode.go
@@ -1,6 +1,8 @@
 package u
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -15,4 +17,33 @@ var Ucode = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// endsuspend and endrepeat are unique to this language, and
+	// \self, /self doesn't seem to get used anywhere else either.
+	var result float32
+
+	if strings.Contains(text, "endsuspend") {
+		result += 0.1
+	}
+
+	if strings.Contains(text, "endrepeat") {
+		result += 0.1
+	}
+
+	if strings.Contains(text, ":=") {
+		result += 0.01
+	}
+
+	if strings.Contains(text, "procedure") && strings.Contains(text, "end") {
+		result += 0.01
+	}
+
+	// This seems quite unique to unicon -- doesn't appear in any other
+	// example source we have (A quick search reveals that \SELF appears in
+	// Perl/Raku code)
+	if strings.Contains(text, `\self`) && strings.Contains(text, "/self") {
+		result += 0.5
+	}
+
+	return result
+}))

--- a/lexers/u/ucode.go
+++ b/lexers/u/ucode.go
@@ -1,0 +1,18 @@
+package u
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ucode lexer.
+var Ucode = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ucode",
+		Aliases:   []string{"ucode"},
+		Filenames: []string{"*.u", "*.u1", "*.u2"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/u/ucode_test.go
+++ b/lexers/u/ucode_test.go
@@ -1,0 +1,51 @@
+package u_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/u"
+)
+
+func TestUcode_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"endsuspend": {
+			Filepath: "testdata/ucode_endsuspend.u",
+			Expected: 0.1,
+		},
+		"endrepeat": {
+			Filepath: "testdata/ucode_endrepeat.u",
+			Expected: 0.1,
+		},
+		"variable set": {
+			Filepath: "testdata/ucode_varset.u",
+			Expected: 0.01,
+		},
+		"procedure": {
+			Filepath: "testdata/ucode_procedure.u",
+			Expected: 0.01,
+		},
+		"self": {
+			Filepath: "testdata/ucode_self.u",
+			Expected: 0.5,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := u.Ucode.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}


### PR DESCRIPTION
this PR ports pygments ucode text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/unicon.py#L389

The documentation does not refer to any of `endsuspend`, `endrepeat` nor `self` keywwords and not to change the default behaviour I created pseudo-codes for them.

doc [here](https://www.tools-of-computing.com/tc/CS/iconprog.pdf).