### PR TITLE
Urbiscript lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -101,7 +101,7 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | `*.ttl`                                              | Tera Term macro  | :x:          |                                     | :heavy_check_mark: |
 |                                                      | Turtle           | :x:          |                                     | :heavy_check_mark: |
 | `*.u`                                                | ucode            | :x:          |                                     | :heavy_check_mark: |
-|                                                      | UrbiScript       | :x:          |                                     |                    |
+|                                                      | UrbiScript       | :x:          |                                     | :heavy_check_mark: |
 | `*.v`                                                | Coq              | :x:          |                                     | :heavy_check_mark: |
 |                                                      | verilog          | :x:          |                                     | :heavy_check_mark: |
 | `*.xsl`                                              | XML              |              |                                     |                    |

--- a/lexers/u/testdata/urbiscript_freezeif.u
+++ b/lexers/u/testdata/urbiscript_freezeif.u
@@ -1,0 +1,4 @@
+timeout(3.2s) detach({ 
+  freezeif(b) every(500ms) echo("tick"), 
+  freezeif(!b) every(500ms) echo("tack") 
+  })|;

--- a/lexers/u/testdata/urbiscript_waituntil.u
+++ b/lexers/u/testdata/urbiscript_waituntil.u
@@ -1,0 +1,1 @@
+waituntil (e?(1, var b)); 

--- a/lexers/u/urbiscript.go
+++ b/lexers/u/urbiscript.go
@@ -1,0 +1,19 @@
+package u
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// UrbiScript lexer.
+var UrbiScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "UrbiScript",
+		Aliases:   []string{"urbiscript"},
+		Filenames: []string{"*.u"},
+		MimeTypes: []string{"application/x-urbiscript"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/u/urbiscript.go
+++ b/lexers/u/urbiscript.go
@@ -1,6 +1,8 @@
 package u
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,18 @@ var UrbiScript = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// This is fairly similar to C and others, but freezeif and
+	// waituntil are unique keywords.
+	var result float32
+
+	if strings.Contains(text, "freezeif") {
+		result += 0.05
+	}
+
+	if strings.Contains(text, "waituntil") {
+		result += 0.05
+	}
+
+	return result
+}))

--- a/lexers/u/urbiscript_test.go
+++ b/lexers/u/urbiscript_test.go
@@ -1,0 +1,39 @@
+package u_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/u"
+)
+
+func TestUrbiScript_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"freezeif": {
+			Filepath: "testdata/urbiscript_freezeif.u",
+			Expected: 0.05,
+		},
+		"waituntil": {
+			Filepath: "testdata/urbiscript_waituntil.u",
+			Expected: 0.05,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := u.UrbiScript.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}


### PR DESCRIPTION
this PR ports pygments UrbiScript text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/urbi.py#L135