### PR TITLE
Update lexer todo document

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -6,109 +6,345 @@ For the following lexers, text analysis capabilities of pygments have to be port
 
 ### Top languages
 
-| file extension | lexer          | done               |
-| ---            | ---            | ---                |
-| `*.as`         | ActionScript   | :heavy_check_mark: |
-|                | ActionScript 3 | :heavy_check_mark: |
-| `*.asm`        | NASM           | :heavy_check_mark: |
-|                | TASM           | :heavy_check_mark: |
-| `*.bas`        | QBasic         | :heavy_check_mark: |
-|                | VB.net         | :heavy_check_mark: |
-| `*.c`          | C              | :heavy_check_mark: |
-|                | C++            | :heavy_check_mark: |
-| `*.fs`         | Forth          | :heavy_check_mark: |
-|                | FSharp         | :heavy_check_mark: |
-| `*.h`          | C              | :heavy_check_mark: |
-|                | C++            | :heavy_check_mark: |
-|                | Objective-C    | :heavy_check_mark: |
-| `*.inc`        | POVRay         | :heavy_check_mark: |
-|                | PHP            | :heavy_check_mark: |
-| `*.m`          | Mason          | :heavy_check_mark: |
-|                | Matlab         | :heavy_check_mark: |
-|                | Objective-C    | :heavy_check_mark: |
-|                | Octave         | :heavy_check_mark: |
-| `*.mc`         | Mason          | :heavy_check_mark: |
-|                | MonkeyC        |                    |
-| `*.pl`         | Perl           | :heavy_check_mark: |
-|                | Prolog         | :heavy_check_mark: |
-| `*.s`          | GAS            | :heavy_check_mark: |
-|                | R              | :heavy_check_mark: |
-| `*.sql`        | MySQL          | :heavy_check_mark: |
-|                | SQL            | :heavy_check_mark: |
-| `*.ts`         | TypeScript     |                    |
-|                | TypoScript     |                    |
-| `*.v`          | Coq            | :heavy_check_mark: |
-|                | verilog        | :heavy_check_mark: |
-| `*.xslt`       | HTML           | :heavy_check_mark: |
-|                | XML            |                    |
+| lexer                         | note                                | lexer done         | text analysis done |
+| ---                           | ---                                 | ---                | ---                |
+| ActionScript                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| ActionScript 3                |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| C                             |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| C++                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Coldfusion HTML               |                                     | :heavy_check_mark: |                    |
+| Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Crontab                       |                                     | :heavy_check_mark: |                    |
+| Delphi                        |                                     | :heavy_check_mark: |                    |
+| Forth                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| FSharp                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| GAS                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Gosu                          |                                     | :heavy_check_mark: |                    |
+| HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Lasso                         |                                     | :heavy_check_mark: |                    |
+| LessCss                       |                                     | :heavy_check_mark: |                    |
+| liquid                        |                                     | :heavy_check_mark: |                    |
+| Marko                         |                                     | :heavy_check_mark: |                    |
+| Mason                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Matlab                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Modelica                      |                                     | :heavy_check_mark: |                    |
+| MonkeyC                       |                                     |                    |                    |
+| Mustache                      |                                     | :heavy_check_mark: |                    |
+| MySQL                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| NASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| NewLisp                       |                                     | :heavy_check_mark: |                    |
+| Objective-C                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Objective-J                   |                                     | :heavy_check_mark: |                    |
+| Octave                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Pawn                          |                                     | :heavy_check_mark: |                    |
+| Perl                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| PHP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| POVRay                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Prolog                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Pug                           |                                     | :heavy_check_mark: |                    |
+| QML                           |                                     | :heavy_check_mark: |                    |
+| R                             |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| RPMSpec                       |                                     | :heavy_check_mark: |                    |
+| Sketch Drawing                |                                     | :heavy_check_mark: |                    |
+| Slim                          |                                     | :heavy_check_mark: |                    |
+| Smali                         |                                     | :heavy_check_mark: |                    |
+| SourcePawn                    |                                     | :heavy_check_mark: |                    |
+| SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Sublime Text Config           |                                     | :heavy_check_mark: |                    |
+| Svelte                        |                                     | :heavy_check_mark: |                    |
+| SWIG                          |                                     | :heavy_check_mark: |                    |
+| TypeScript                    |                                     | :heavy_check_mark: |                    |
+| TypoScript                    |                                     | :heavy_check_mark: |                    |
+| QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| VB.net                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| VCL                           |                                     | :heavy_check_mark: |                    |
+| Velocity                      |                                     | :heavy_check_mark: |                    |
+| verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| XAML                          |                                     | :heavy_check_mark: |                    |
+| XML                           |                                     |                    |                    |
+| XSLT                          |                                     | :heavy_check_mark: |                    |
+
 
 ### Long tail languages
 
-| file extension(s)                                    | lexer            | lexer exists | note                                | done               |
-| ---                                                  | ---              | ---          | ---                                 | ---                |
-| `*.asax`,`*.ascx`,`*.ashx`,`*.asmx`,`*.aspx`,`*.axd` | aspx-cs          | :x:          |                                     | :heavy_check_mark: |
-|                                                      | aspx-vb          | :x:          |                                     | :heavy_check_mark: |
-| `*.ASM`                                              | NASM             | :x:          |                                     | :heavy_check_mark: |
-|                                                      | TASM             | :x:          |                                     | :heavy_check_mark: |
-| `*.S`                                                | GAS              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | S                | :x:          | It's implemented altogether in r.go | :heavy_check_mark: |
-| `*.b`                                                | Brainfuck        | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Limbo            | :x:          |                                     | :heavy_check_mark: |
-| `*.bas`                                              | CBM BASIC V2     | :x:          |                                     | :heavy_check_mark: |
-|                                                      | QBasic           | :x:          |                                     | :heavy_check_mark: |
-|                                                      | VB.net           | :x:          |                                     | :heavy_check_mark: |
-| `*.bug`                                              | BUGS             | :x:          |                                     | :heavy_check_mark: |
-|                                                      | JAGS             | :x:          |                                     | :heavy_check_mark: |
-| `*.def`                                              | Modula-2         | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Singularity      | :x:          |                                     | :heavy_check_mark: |
-| `*.ecl`                                              | ECL              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Prolog           | :x:          |                                     | :heavy_check_mark: |
-| `*.gd`                                               | GAP              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | GDScript         | :x:          |                                     | :heavy_check_mark: |
-| `*.hy`                                               | Hy               | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Hybris           | :x:          |                                     | :heavy_check_mark: |
-| `*.inc`                                              | Pawn             | :x:          |                                     | :heavy_check_mark: |
-|                                                      | PHP              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | POVRay           | :x:          |                                     | :heavy_check_mark: |
-| `*.inf`                                              | Inform 6         | :x:          |                                     | :heavy_check_mark: |
-|                                                      | INI              | :x:          |                                     | :heavy_check_mark: |
-| `*.j`                                                | Jasmin           | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Objective-J      | :x:          |                                     | :heavy_check_mark: |
-| `*.n`                                                | Ezhil            | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Nemerle          | :x:          |                                     | :heavy_check_mark: |
-| `*.p`                                                | OpenEdge ABL     | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Pawn             | :x:          |                                     | :heavy_check_mark: |
-| `*.pl`                                               | Perl6            | :x:          |                                     |                    |
-|                                                      | Perl             | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Prolog           | :x:          |                                     | :heavy_check_mark: |
-| `*.pm`                                               | Perl6            | :x:          |                                     |                    |
-|                                                      | Perl             | :x:          |                                     | :heavy_check_mark: |
-| `*.pro`                                              | IDL              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Prolog           | :x:          |                                     | :heavy_check_mark: |
-| `*.s`                                                | ca65 assembler   | :x:          |                                     | :heavy_check_mark: |
-|                                                      | GAS              | :x:          |                                     | :heavy_check_mark: |
-| `*.sc`                                               | Python           |              |                                     |                    |
-|                                                      | SuperCollider    | :x:          |                                     | :heavy_check_mark: |
-| `*.scd`                                              | scdoc            | :x:          |                                     | :heavy_check_mark: |
-|                                                      | SuperCollider    | :x:          |                                     | :heavy_check_mark: |
-| `*.sl`                                               | Slash            | :x:          | No text analysis exists in pygments |                    |
-|                                                      | Slurm            | :x:          | No text analysis exists in pygments |                    |
-| `*.sql`                                              | SQL              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Transact-SQL     | :x:          |                                     | :heavy_check_mark: |
-| `*.t`                                                | Perl6            |              |                                     |                    |
-|                                                      | Perl             |              |                                     |                    |
-|                                                      | TADS 3           | :x:          |                                     | :heavy_check_mark: |
-| `*.ttl`                                              | Tera Term macro  | :x:          |                                     | :heavy_check_mark: |
-|                                                      | Turtle           | :x:          |                                     | :heavy_check_mark: |
-| `*.u`                                                | ucode            | :x:          |                                     | :heavy_check_mark: |
-|                                                      | UrbiScript       | :x:          |                                     | :heavy_check_mark: |
-| `*.v`                                                | Coq              | :x:          |                                     | :heavy_check_mark: |
-|                                                      | verilog          | :x:          |                                     | :heavy_check_mark: |
-| `*.xsl`                                              | XML              |              |                                     |                    |
-|                                                      | XSLT             | :x:          |                                     |                    |
-| `*.xslt`                                             | HTML             | :x:          |                                     | :heavy_check_mark: |
-|                                                      | XML              |              |                                     |                    |
-|                                                      | XSLT             | :x:          |                                     |                    |
+| lexer                         | note                                | lexer done         | text analysis done |
+| ---                           | ---                                 | ---                |                    |
+| ADL                           |                                     |                    |                    |
+| Agda                          |                                     |                    |                    |
+| Aheui                         |                                     |                    |                    |
+| Alloy                         |                                     |                    |                    |
+| AmbientTalk                   |                                     |                    |                    |
+| Ampl                          |                                     |                    |                    |
+| Arrow                         |                                     |                    |                    |
+| AspectJ                       |                                     |                    |                    |
+| aspx-cs                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| aspx-vb                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Asymptote                     |                                     |                    |                    |
+| Augeas                        |                                     |                    |                    |
+| AutoIt                        |                                     |                    |                    |
+| autohotkey                    |                                     |                    |                    |
+| BBC Basic                     |                                     |                    |                    |
+| BBCode                        |                                     |                    |                    |
+| BC                            |                                     |                    |                    |
+| BST                           |                                     |                    |                    |
+| BARE                          |                                     |                    |                    |
+| Bash Session                  |                                     |                    |                    |
+| Befunge                       |                                     |                    |                    |
+| BlitzMax                      |                                     |                    |                    |
+| Boa                           |                                     |                    |                    |
+| Boo                           |                                     |                    |                    |
+| Boogie                        |                                     |                    |                    |
+| Brainfuck                     |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| BUGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| c-objdump                     |                                     |                    |                    |
+| ca65 assembler                |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| CAmkES                        |                                     |                    |                    |
+| CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| CPSA                          |                                     |                    |                    |
+| cADL                          |                                     |                    |                    |
+| CapDL                         |                                     |                    |                    |
+| Chapel                        |                                     |                    |                    |
+| Charmci                       |                                     |                    |                    |
+| Cirru                         |                                     |                    |                    |
+| Clay                          |                                     |                    |                    |
+| Clean                         |                                     |                    |                    |
+| ClojureScript                 |                                     |                    |                    |
+| COBOLFree                     |                                     |                    |                    |
+| Coldfusion CFC                |                                     |                    |                    |
+| Common Lisp                   | Lexer exists in chroma              | :heavy_check_mark: |                    |
+| Component Pascal              |                                     |                    |                    |
+| Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| cpp-objdump                   |                                     |                    |                    |
+| Crmsh                         |                                     |                    |                    |
+| Croc                          |                                     |                    |                    |
+| Cryptol                       |                                     |                    |                    |
+| Csound Document               |                                     |                    |                    |
+| Csound Orchestra              |                                     |                    |                    |
+| Csound Score                  |                                     |                    |                    |
+| CUDA                          |                                     |                    |                    |
+| Cypher                        |                                     |                    |                    |
+| d-objdump                     |                                     |                    |                    |
+| Darcs Patch                   |                                     |                    |                    |
+| DASM16                        |                                     |                    |                    |
+| Debian Control file           |                                     |                    |                    |
+| Devicetree                    |                                     |                    |                    |
+| dg                            |                                     |                    |                    |
+| Duel                          |                                     |                    |                    |
+| Dylan session                 |                                     |                    |                    |
+| Dylan                         |                                     |                    |                    |
+| DylanLID                      |                                     |                    |                    |
+| E-mail                        |                                     |                    |                    |
+| eC                            |                                     |                    |                    |
+| Earl Grey                     |                                     |                    |                    |
+| Easytrieve                    |                                     |                    |                    |
+| ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Eiffel                        |                                     |                    |                    |
+| Elixir iex session            |                                     |                    |                    |
+| EmacsLisp                     |  Lexer exists in chroma             | :heavy_check_mark: |                    |
+| ERB                           |                                     |                    |                    |
+| Erlang erl session            |                                     |                    |                    |
+| Evoque                        |                                     |                    |                    |
+| execline                      |                                     |                    |                    |
+| Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| F#                            |                                     |                    |                    |
+| FStar                         |                                     |                    |                    |
+| Fancy                         |                                     |                    |                    |
+| Fantom                        |                                     |                    |                    |
+| Felix                         |                                     |                    |                    |
+| Fennel                        |                                     |                    |                    |
+| Flatline                      |                                     |                    |                    |
+| FloScript                     |                                     |                    |                    |
+| FortranFixed                  |                                     |                    |                    |
+| FoxPro                        |                                     |                    |                    |
+| Freefem                       |                                     |                    |                    |
+| GAP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| GAS                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| GDScript                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Gettext Catalog               |                                     |                    |                    |
+| Golo                          |                                     |                    |                    |
+| GoodData-CL                   |                                     |                    |                    |
+| Groff                         |                                     |                    |                    |
+| HLSL                          |                                     |                    |                    |
+| Haml                          |                                     |                    |                    |
+| HSAIL                         |                                     |                    |                    |
+| Hspec                         |                                     |                    |                    |
+| HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| HTTP                          |  Lexer exists in chroma             | :heavy_check_mark: |                    |
+| Hxml                          |                                     |                    |                    |
+| Hy                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Hybris                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Icon                          |                                     |                    |                    |
+| IDL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| INI                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Inform 6                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Inform 6 template             |                                     |                    |                    |
+| Inform 7                      |                                     |                    |                    |
+| Ioke                          |                                     |                    |                    |
+| IRC logs                      |                                     |                    |                    |
+| Isabelle                      |                                     |                    |                    |
+| JAGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Jasmin                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| JCL                           |                                     |                    |                    |
+| JSGF                          |                                     |                    |                    |
+| JSONBareObject                |                                     |                    |                    |
+| JSON-LD                       |                                     |                    |                    |
+| Java Server Page              |                                     |                    |                    |
+| Julia console                 |                                     |                    |                    |
+| Juttle                        |                                     |                    |                    |
+| Kal                           |                                     |                    |                    |
+| Kconfig                       |                                     |                    |                    |
+| Kernel log                    |                                     |                    |                    |
+| Koka                          |                                     |                    |                    |
+| LSL                           |                                     |                    |                    |
+| Lean                          |                                     |                    |                    |
+| Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Literate Agda                 |                                     |                    |                    |
+| Literate Cryptol              |                                     |                    |                    |
+| Literate Haskell              |                                     |                    |                    |
+| Literate Idris                |                                     |                    |                    |
+| LiveScript                    |                                     |                    |                    |
+| LLVM-MIR Body                 |                                     |                    |                    |
+| LLVM-MIR                      |                                     |                    |                    |
+| Logos                         |                                     |                    |                    |
+| Logtalk                       |                                     |                    |                    |
+| MIME                          |                                     |                    |                    |
+| MOOCode                       |                                     |                    |                    |
+| MSDOS Session                 |                                     |                    |                    |
+| Makefile                      |                                     |                    |                    |
+| MAQL                          |                                     |                    |                    |
+| markdown                      |  Lexer exists in chroma             | :heavy_check_mark: |                    |
+| Mask                          |                                     |                    |                    |
+| Matlab session                |                                     |                    |                    |
+| MiniD                         |                                     |                    |                    |
+| MiniScript                    |                                     |                    |                    |
+| Modula-2                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| MoinMoin/Trac Wiki markup     |                                     |                    |                    |
+| Monkey                        |                                     |                    |                    |
+| Monte                         |                                     |                    |                    |
+| MoonScript                    |                                     |                    |                    |
+| Mosel                         |                                     |                    |                    |
+| mozhashpreproc                |                                     |                    |                    |
+| mozpercentpreproc             |                                     |                    |                    |
+| MQL                           |                                     |                    |                    |
+| Mscgen                        |                                     |                    |                    |
+| MuPAD                         |                                     |                    |                    |
+| MXML                          |                                     |                    |                    |
+| NASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| NCL                           |                                     |                    |                    |
+| Nemerle                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| NSIS                          |                                     |                    |                    |
+| objdump-nasm                  |                                     |                    |                    |
+| nesC                          |                                     |                    |                    |
+| Nimrod                        |                                     |                    |                    |
+| Nit                           |                                     |                    |                    |
+| Notmuch                       |                                     |                    |                    |
+| NuSMV                         |                                     |                    |                    |
+| NumPy                         |                                     |                    |                    |
+| objdump                       |                                     |                    |                    |
+| Objective-J                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| ODIN                          |                                     |                    |                    |
+| Ooc                           |                                     |                    |                    |
+| Opa                           |                                     |                    |                    |
+| OpenEdge ABL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Pan                           |                                     |                    |                    |
+| ParaSail                      |                                     |                    |                    |
+| Pawn                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| PEG                           |                                     |                    |                    |
+| Perl6                         |                                     |                    |                    |
+| PHP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Pike                          |                                     |                    |                    |
+| Pointless                     |                                     |                    |                    |
+| PostgreSQL console (psql)     |                                     |                    |                    |
+| POVRay                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| PowerShell Session            |                                     |                    |                    |
+| Praat                         |                                     |                    |                    |
+| Prolog                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Properties                    |                                     |                    |                    |
+| PsySH console session for PHP |                                     |                    |                    |
+| PyPy Log                      |                                     |                    |                    |
+| Python                        |                                     |                    |                    |
+| Python 2.x                    |                                     |                    |                    |
+| Python 2.x Traceback          |                                     |                    |                    |
+| Python console session        |                                     |                    |                    |
+| Python Traceback              |                                     |                    |                    |
+| QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| QVTO                          |                                     |                    |                    |
+| RConsole                      |                                     |                    |                    |
+| Relax-NG Compact              |                                     |                    |                    |
+| Embedded Ragel                |                                     |                    |                    |
+| Raw token data                |                                     |                    |                    |
+| Rd                            |                                     |                    |                    |
+| REBOL                         |                                     |                    |                    |
+| Red                           |                                     |                    |                    |
+| Redcode                       |                                     |                    |                    |
+| ResourceBundle                |                                     |                    |                    |
+| RHTML                         |                                     |                    |                    |
+| Ride                          |                                     |                    |                    |
+| Roboconf Graph                |                                     |                    |                    |
+| Roboconf Instances            |                                     |                    |                    |
+| RobotFramework                |                                     |                    |                    |
+| RQL                           |                                     |                    |                    |
+| RSL                           |                                     |                    |                    |
+| TrafficScript                 |                                     |                    |                    |
+| Ruby irb session              |                                     |                    |                    |
+| scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
+| SARL                          |                                     |                    |                    |
+| Scaml                         |                                     |                    |                    |
+| ShExC                         |                                     |                    |                    |
+| Shen                          |                                     |                    |                    |
+| Sieve                         |                                     |                    |                    |
+| Silver                        |                                     |                    |                    |
+| Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Slash                         | No text analysis exists in pygments |                    |                    |
+| Slurm                         | No text analysis exists in pygments |                    |                    |
+| SmartGameFormat               |                                     |                    |                    |
+| Snowball                      |                                     |                    |                    |
+| SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Debian Sourcelist             |                                     |                    |                    |
+| sqlite3con                    |                                     |                    |                    |
+| Scalate Server Page           |                                     |                    |                    |
+| Stan                          |                                     |                    |                    |
+| Stata                         |                                     |                    |                    |
+| TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| TAP                           |                                     |                    |                    |
+| TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Tcsh Session                  |                                     |                    |                    |
+| Tea                           |                                     |                    |                    |
+| Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Text only                     |                                     |                    |                    |
+| tiddler                       |                                     |                    |                    |
+| Todotxt                       |                                     |                    |                    |
+| Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Treetop                       |                                     |                    |                    |
+| Turtle                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Typographic Number Theory     |                                     |                    |                    |
+| ucode                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Unicon                        |                                     |                    |                    |
+| UrbiScript                    |                                     |                    |                    |
+| USD                           |                                     |                    |                    |
+| VB.net                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| VBScript                      |                                     |                    |                    |
+| VCLSnippets                   |                                     |                    |                    |
+| VCTreeStatus                  |                                     |                    |                    |
+| verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| VGL                           |                                     |                    |                    |
+| Vala                          |                                     |                    |                    |
+| vhdl                          |                                     |                    |                    |
+| WDiff                         |                                     |                    |                    |
+| Web IDL                       |                                     |                    |                    |
+| Whiley                        |                                     |                    |                    |
+| X10                           |                                     |                    |                    |
+| XQuery                        |                                     |                    |                    |
+| XSLT                          |                                     |                    |                    |
+| Xtend                         |                                     |                    |                    |
+| xtlang                        |                                     |                    |                    |
+| Zeek                          |                                     |                    |                    |
+| Zephir                        |                                     |                    |                    |
+
 
 ## Missing file extension support
 


### PR DESCRIPTION
This PR updates the lexer todo document to provide a complete plan to support all pygments lexers in chroma. This was created with the help of an analysis script. Not every lexer was checked manually.

We can discuss here, if certain lexers are not necessary or discuss this, once somebody picks up a specific lexer for coding. In the markdown tables is a field `note`, where we can document any findings, decisions etc.

- Lexer lists were merged and organized in `top languages` `long tail languages`
- Tables were extended to have 2 columns to mark if the general lexer was done, and if the text analysis porting was done. These can also be done in one PR.