### PR TITLE
Add ADL lexer

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -65,8 +65,8 @@
 ## Long tail languages
 
 | lexer                         | note                                | lexer done         | text analysis done |
-| ---                           | ---                                 | ---                | ---                |
-| ADL                           |                                     |                    |                    |
+| ---                           | ---                                 | ---                |                    |
+| ADL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Agda                          |                                     |                    |                    |
 | Aheui                         |                                     |                    |                    |
 | Alloy                         |                                     |                    |                    |

--- a/lexers/a/adl.go
+++ b/lexers/a/adl.go
@@ -1,0 +1,18 @@
+package a
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ADL lexer.
+var Adl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ADL",
+		Aliases:   []string{"adl"},
+		Filenames: []string{"*.adl", "*.adls", "*.adlf", "*.adlx"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds basic ADL lexer support.

`lexers/TODO.md` document was cherry picked from update-lexer-todo branch.