### PR TITLE
Clean up lexer todo document

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -1,10 +1,6 @@
 # Wakatime lexer support
 
-## Text analysis
-
-For the following lexers, text analysis capabilities of pygments have to be ported to chroma for the wakatime golang client to work. In general we focus on lexers, which are associated with the same file extension. If the lexer doesn't even exist in chroma yet, it has to be added.
-
-### Top languages
+## Top languages
 
 | lexer                         | note                                | lexer done         | text analysis done |
 | ---                           | ---                                 | ---                | ---                |
@@ -66,10 +62,10 @@ For the following lexers, text analysis capabilities of pygments have to be port
 | XSLT                          |                                     | :heavy_check_mark: |                    |
 
 
-### Long tail languages
+## Long tail languages
 
 | lexer                         | note                                | lexer done         | text analysis done |
-| ---                           | ---                                 | ---                |                    |
+| ---                           | ---                                 | ---                | ---                |
 | ADL                           |                                     |                    |                    |
 | Agda                          |                                     |                    |                    |
 | Aheui                         |                                     |                    |                    |
@@ -360,51 +356,6 @@ For the following lexers, file extension support has to be added, to match the b
 | Python      | `*.jy`, `*.bzl`, `BUCK`, `BUILD`, `BUILD.bazel`, `WORKSPACE` | :heavy_check_mark:                    |
 | TOML        | `Pipfile`, `poetry.lock`                                     | :heavy_check_mark:                    |
 | Twig        | `*.twig`                                                     | :heavy_check_mark:                    |
-
-### Long tail
-
-TBD
-
-## Missing lexers
-
-The following lexers exist in pygments, but not in chroma. They have to be added to emulate the behaviour of pygments, which is the baseline for the wakatime cli.
-
-Only a very stripped down version is necessary here, though. No token related be functionality is needed and we really only care about 2 things here:
-
-1. The lexer name, should match the pygments lexer name.
-2. Associated file name pattern have to be identical to pygments.
-
-### Top languages
-
-| lexer               | filename pattern                            | not in pygments | done               |
-| ---                 | ---                                         | ---             | ---                |
-| Crontab             | `crontab`                                   | :x:             | :heavy_check_mark: |
-| Coldfusion HTML     | `.cfm`, `*.cfml`                            |                 | :heavy_check_mark: |
-| Delphi              | `.pas`, `*.dpr`                             |                 | :heavy_check_mark: |
-| Gosu                | `*.gs`, `*.gsp`, `*.gst`, `*.gsx`, `*.vark` |                 | :heavy_check_mark: |
-| Lasso               | `*.lasso`, `*.lasso[89]`                    |                 | :heavy_check_mark: |
-| LessCss             | `*.less`                                    |                 | :heavy_check_mark: |
-| liquid              | `*.liquid`                                  |                 | :heavy_check_mark: |
-| Marko               | `*.marko`                                   | :x:             | :heavy_check_mark: |
-| Modelica            | `*.mo`                                      |                 | :heavy_check_mark: |
-| Mustache            | `*.mustache`                                | :x:             | :heavy_check_mark: |
-| NewLisp             | `*.lsp`, `*.nl`, `*.kif`                    |                 | :heavy_check_mark: |
-| Objective-J         | `*.j`                                       |                 | :heavy_check_mark: |
-| Pawn                | `*.p`, `*.pwn`, `*.inc`                     |                 | :heavy_check_mark: |
-| Pug                 | `*.pug`, `*.jade`                           |                 | :heavy_check_mark: |
-| QML                 | `*.qml`, `*.qbs`                            |                 | :heavy_check_mark: |
-| RPMSpec             | `*.spec`                                    |                 | :heavy_check_mark: |
-| Sketch Drawing      | `*.sketch`                                  | :x:             | :heavy_check_mark: |
-| Slim                | `*.slim`                                    |                 | :heavy_check_mark: |
-| Smali               | `*.smali`                                   |                 | :heavy_check_mark: |
-| SourcePawn          | `*.sp`                                      |                 | :heavy_check_mark: |
-| Sublime Text Config | `*.sublime-settings`                        | :x:             | :heavy_check_mark: |
-| Svelte              | `*.svelte`                                  | :x:             | :heavy_check_mark: |
-| SWIG                | `*.swg`, `*.i`                              |                 | :heavy_check_mark: |
-| VCL                 | `*.vcl`                                     |                 | :heavy_check_mark: |
-| Velocity            | `*.vm`, `*.fhtml`                           |                 | :heavy_check_mark: |
-| XAML                | `*.xaml`                                    | :x:             | :heavy_check_mark: |
-| XSLT                | `*.xsl`, `*.xslt`, `*.xpl` # xpl is XProc   |                 | :heavy_check_mark: |
 
 ### Long tail
 


### PR DESCRIPTION
This PR cleans up lexer todo list, which was updated in #71. Formatting of second table was messed up and some old parts should've been removed.

This happens if you create and merge PRs in a hurry :sweat_smile: 