### PR TITLE
C lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -116,7 +116,7 @@
 | cpp-objdump                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Crmsh                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Croc                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Cryptol                       |                                     |                    |                    |
+| Cryptol                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Document               |                                     |                    |                    |
 | Csound Orchestra              |                                     |                    |                    |
 | Csound Score                  |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -109,7 +109,7 @@
 | Clean                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ClojureScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | COBOLFree                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Coldfusion CFC                |                                     |                    |                    |
+| Coldfusion CFC                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Common Lisp                   | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | Component Pascal              |                                     |                    |                    |
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -115,7 +115,7 @@
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | cpp-objdump                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Crmsh                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Croc                          |                                     |                    |                    |
+| Croc                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Cryptol                       |                                     |                    |                    |
 | Csound Document               |                                     |                    |                    |
 | Csound Orchestra              |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -113,7 +113,7 @@
 | Common Lisp                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Component Pascal              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| cpp-objdump                   |                                     |                    |                    |
+| cpp-objdump                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Crmsh                         |                                     |                    |                    |
 | Croc                          |                                     |                    |                    |
 | Cryptol                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -92,7 +92,7 @@
 | Boogie                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Brainfuck                     |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | BUGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| c-objdump                     |                                     |                    |                    |
+| c-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ca65 assembler                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | CAmkES                        |                                     |                    |                    |
 | CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -120,7 +120,7 @@
 | Csound Document               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Orchestra              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Score                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| CUDA                          |                                     |                    |                    |
+| CUDA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Cypher                        |                                     |                    |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -110,7 +110,7 @@
 | ClojureScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | COBOLFree                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coldfusion CFC                | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Common Lisp                   | Lexer exists in chroma              | :heavy_check_mark: |                    |
+| Common Lisp                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Component Pascal              |                                     |                    |                    |
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | cpp-objdump                   |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -120,7 +120,7 @@
 | Csound Document               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Orchestra              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Score                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| CUDA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| CUDA                          | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
 | Cypher                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -111,7 +111,7 @@
 | COBOLFree                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coldfusion CFC                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Common Lisp                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Component Pascal              |                                     |                    |                    |
+| Component Pascal              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | cpp-objdump                   |                                     |                    |                    |
 | Crmsh                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -117,7 +117,7 @@
 | Crmsh                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Croc                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Cryptol                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Csound Document               |                                     |                    |                    |
+| Csound Document               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Orchestra              |                                     |                    |                    |
 | Csound Score                  |                                     |                    |                    |
 | CUDA                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -106,7 +106,7 @@
 |                               | analysis based on C++ on it.        |                    |                    |
 | Cirru                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clay                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Clean                         |                                     |                    |                    |
+| Clean                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ClojureScript                 |                                     |                    |                    |
 | COBOLFree                     |                                     |                    |                    |
 | Coldfusion CFC                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -108,7 +108,7 @@
 | Clay                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clean                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ClojureScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| COBOLFree                     |                                     |                    |                    |
+| COBOLFree                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coldfusion CFC                |                                     |                    |                    |
 | Common Lisp                   | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | Component Pascal              |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -98,7 +98,7 @@
 | CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | CPSA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | cADL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| CapDL                         |                                     |                    |                    |
+| CapDL                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Chapel                        |                                     |                    |                    |
 | Charmci                       |                                     |                    |                    |
 | Cirru                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -107,7 +107,7 @@
 | Cirru                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clay                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clean                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| ClojureScript                 |                                     |                    |                    |
+| ClojureScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | COBOLFree                     |                                     |                    |                    |
 | Coldfusion CFC                |                                     |                    |                    |
 | Common Lisp                   | Lexer exists in chroma              | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -94,7 +94,7 @@
 | BUGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | c-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ca65 assembler                |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| CAmkES                        |                                     |                    |                    |
+| CAmkES                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | CPSA                          |                                     |                    |                    |
 | cADL                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -121,7 +121,7 @@
 | Csound Orchestra              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Score                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CUDA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Cypher                        |                                     |                    |                    |
+| Cypher                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DASM16                        | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -96,7 +96,7 @@
 | ca65 assembler                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | CAmkES                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| CPSA                          |                                     |                    |                    |
+| CPSA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | cADL                          |                                     |                    |                    |
 | CapDL                         |                                     |                    |                    |
 | Chapel                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -105,7 +105,7 @@
 |                               | and there's no reason to have text  |                    |                    |
 |                               | analysis based on C++ on it.        |                    |                    |
 | Cirru                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Clay                          |                                     |                    |                    |
+| Clay                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clean                         |                                     |                    |                    |
 | ClojureScript                 |                                     |                    |                    |
 | COBOLFree                     |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -114,7 +114,7 @@
 | Component Pascal              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Coq                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | cpp-objdump                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Crmsh                         |                                     |                    |                    |
+| Crmsh                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Croc                          |                                     |                    |                    |
 | Cryptol                       |                                     |                    |                    |
 | Csound Document               |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -97,7 +97,7 @@
 | CAmkES                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CBM BASIC V2                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | CPSA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| cADL                          |                                     |                    |                    |
+| cADL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CapDL                         |                                     |                    |                    |
 | Chapel                        |                                     |                    |                    |
 | Charmci                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -100,7 +100,10 @@
 | cADL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CapDL                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Chapel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Charmci                       |                                     |                    |                    |
+| Charmci                       | Text analysis inherits from C++.    | :heavy_check_mark: | :heavy_check_mark: |
+|                               | However ci file is only interface   |                    |                    |
+|                               | and there's no reason to have text  |                    |                    |
+|                               | analysis based on C++ on it.        |                    |                    |
 | Cirru                         |                                     |                    |                    |
 | Clay                          |                                     |                    |                    |
 | Clean                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -118,7 +118,7 @@
 | Croc                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Cryptol                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Document               | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Csound Orchestra              |                                     |                    |                    |
+| Csound Orchestra              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Score                  |                                     |                    |                    |
 | CUDA                          |                                     |                    |                    |
 | Cypher                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -119,7 +119,7 @@
 | Cryptol                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Document               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Csound Orchestra              | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Csound Score                  |                                     |                    |                    |
+| Csound Score                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CUDA                          |                                     |                    |                    |
 | Cypher                        |                                     |                    |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -99,7 +99,7 @@
 | CPSA                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | cADL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | CapDL                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Chapel                        |                                     |                    |                    |
+| Chapel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Charmci                       |                                     |                    |                    |
 | Cirru                         |                                     |                    |                    |
 | Clay                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -104,7 +104,7 @@
 |                               | However ci file is only interface   |                    |                    |
 |                               | and there's no reason to have text  |                    |                    |
 |                               | analysis based on C++ on it.        |                    |                    |
-| Cirru                         |                                     |                    |                    |
+| Cirru                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Clay                          |                                     |                    |                    |
 | Clean                         |                                     |                    |                    |
 | ClojureScript                 |                                     |                    |                    |

--- a/lexers/c/cadl.go
+++ b/lexers/c/cadl.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cadl lexer.
+var Cadl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "cADL",
+		Aliases:   []string{"cadl"},
+		Filenames: []string{"*.cadl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/camkes.go
+++ b/lexers/c/camkes.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CAmkES lexer.
+var CAmkES = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "CAmkES",
+		Aliases:   []string{"camkes", "idl4"},
+		Filenames: []string{"*.camkes", "*.idl4"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/capdl.go
+++ b/lexers/c/capdl.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Capdl lexer.
+var Capdl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "CapDL",
+		Aliases:   []string{"capdl"},
+		Filenames: []string{"*.cdl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/chapel.go
+++ b/lexers/c/chapel.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Chapel lexer.
+var Chapel = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Chapel",
+		Aliases:   []string{"chapel", "chpl"},
+		Filenames: []string{"*.chpl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/charmci.go
+++ b/lexers/c/charmci.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Charmci lexer.
+var Charmci = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Charmci",
+		Aliases:   []string{"charmci"},
+		Filenames: []string{"*.ci"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cirru.go
+++ b/lexers/c/cirru.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cirru lexer.
+var Cirru = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Cirru",
+		Aliases:   []string{"cirru"},
+		Filenames: []string{"*.cirru"},
+		MimeTypes: []string{"text/x-cirru"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/clay.go
+++ b/lexers/c/clay.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Clay lexer.
+var Clay = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Clay",
+		Aliases:   []string{"clay"},
+		Filenames: []string{"*.clay"},
+		MimeTypes: []string{"text/x-clay"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/clean.go
+++ b/lexers/c/clean.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Clean lexer.
+var Clean = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Clean",
+		Aliases:   []string{"clean"},
+		Filenames: []string{"*.icl", "*.dcl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/clojurescript.go
+++ b/lexers/c/clojurescript.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ClojureScript lexer.
+var ClojureScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ClojureScript",
+		Aliases:   []string{"clojurescript", "cljs"},
+		Filenames: []string{"*.cljs"},
+		MimeTypes: []string{"text/x-clojurescript", "application/x-clojurescript"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cobjdump.go
+++ b/lexers/c/cobjdump.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CObjdump lexer.
+var CObjdump = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "c-objdump",
+		Aliases:   []string{"c-objdump"},
+		Filenames: []string{"*.c-objdump"},
+		MimeTypes: []string{"text/x-c-objdump"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cobolfree.go
+++ b/lexers/c/cobolfree.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CobolFree lexer.
+var CobolFree = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "COBOLFree",
+		Aliases:   []string{"cobolfree"},
+		Filenames: []string{"*.cbl", "*.CBL"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/coldfusioncfc.go
+++ b/lexers/c/coldfusioncfc.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ColdfusionCfc lexer.
+var ColdfusionCfc = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Coldfusion CFC",
+		Aliases:   []string{"cfc"},
+		Filenames: []string{"*.cfc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/componentpascal.go
+++ b/lexers/c/componentpascal.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ComponentPascal lexer.
+var ComponentPascal = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Component Pascal",
+		Aliases:   []string{"componentpascal", "cp"},
+		Filenames: []string{"*.cp", "*.cps"},
+		MimeTypes: []string{"text/x-component-pascal"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cppobjdump.go
+++ b/lexers/c/cppobjdump.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CppObjdump lexer.
+var CppObjdump = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "cpp-objdump",
+		Aliases:   []string{"cpp-objdump", "c++-objdumb", "cxx-objdump"},
+		Filenames: []string{"*.cpp-objdump", "*.c++-objdump", "*.cxx-objdump"},
+		MimeTypes: []string{"text/x-cpp-objdump"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cpsa.go
+++ b/lexers/c/cpsa.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cpsa lexer.
+var Cpsa = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "CPSA",
+		Aliases:   []string{"cpsa"},
+		Filenames: []string{"*.cpsa"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/crmsh.go
+++ b/lexers/c/crmsh.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Crmsh lexer.
+var Crmsh = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Crmsh",
+		Aliases:   []string{"crmsh", "pcmk"},
+		Filenames: []string{"*.crmsh", "*.pcmk"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/croc.go
+++ b/lexers/c/croc.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Croc lexer.
+var Croc = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Croc",
+		Aliases:   []string{"croc"},
+		Filenames: []string{"*.croc"},
+		MimeTypes: []string{"text/x-crocsrc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cryptol.go
+++ b/lexers/c/cryptol.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cryptol lexer.
+var Cryptol = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Cryptol",
+		Aliases:   []string{"cryptol", "cry"},
+		Filenames: []string{"*.cry"},
+		MimeTypes: []string{"text/x-cryptol"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/csounddocument.go
+++ b/lexers/c/csounddocument.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CsoundDocument lexer.
+var CsoundDocument = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Csound Document",
+		Aliases:   []string{"csound-document", "csound-csd"},
+		Filenames: []string{"*.csd"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/csoundorchestra.go
+++ b/lexers/c/csoundorchestra.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CsoundOrchestra lexer.
+var CsoundOrchestra = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Csound Orchestra",
+		Aliases:   []string{"csound", "csound-orc"},
+		Filenames: []string{"*.orc", "*.udo"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/csoundscore.go
+++ b/lexers/c/csoundscore.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// CsoundScore lexer.
+var CsoundScore = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Csound Score",
+		Aliases:   []string{"csound-score", "csound-sco"},
+		Filenames: []string{"*.sco"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cuda.go
+++ b/lexers/c/cuda.go
@@ -1,0 +1,19 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cuda lexer.
+var Cuda = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "CUDA",
+		Aliases:   []string{"cuda", "cu"},
+		Filenames: []string{"*.cu", "*.cuh"},
+		MimeTypes: []string{"text/x-cuda"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/cuda.go
+++ b/lexers/c/cuda.go
@@ -1,6 +1,7 @@
 package c
 
 import (
+	"github.com/alecthomas/chroma"
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +17,10 @@ var Cuda = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if analyser, ok := C.(chroma.Analyser); ok {
+		return analyser.AnalyseText(text)
+	}
+
+	return 0
+}))

--- a/lexers/c/cuda_test.go
+++ b/lexers/c/cuda_test.go
@@ -1,0 +1,43 @@
+package c_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestCuda_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"include": {
+			Filepath: "testdata/cuda_include.cu",
+			Expected: 0.1,
+		},
+		"ifdef": {
+			Filepath: "testdata/cuda_ifdef.cu",
+			Expected: 0.1,
+		},
+		"ifndef": {
+			Filepath: "testdata/cuda_ifndef.cu",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := c.Cuda.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/c/cypher.go
+++ b/lexers/c/cypher.go
@@ -1,0 +1,18 @@
+package c
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Cypher lexer.
+var Cypher = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Cypher",
+		Aliases:   []string{"cypher"},
+		Filenames: []string{"*.cyp", "*.cypher"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/c/testdata/cuda_ifdef.cu
+++ b/lexers/c/testdata/cuda_ifdef.cu
@@ -1,0 +1,2 @@
+
+#ifdef DEBUG

--- a/lexers/c/testdata/cuda_ifndef.cu
+++ b/lexers/c/testdata/cuda_ifndef.cu
@@ -1,0 +1,2 @@
+
+#ifndef DEBUG

--- a/lexers/c/testdata/cuda_include.cu
+++ b/lexers/c/testdata/cuda_include.cu
@@ -1,0 +1,2 @@
+
+#include <stdio.h>


### PR DESCRIPTION
This PR adds missing `c` package lexers.

- c-objdump
- CAmkES
- CPSA
- cADL
- CapDL
- Chapel
- Charmci - Text analysis inherits from C++. However ci file is only interface and there's no reason to have text analysis based on C++ on it. 
- Cirru
- Clay
- Clean
- ClojureScript
- COBOLFree
- Coldfusion CFC
- Component Pascal
- cpp-objdump
- Crmsh
- Csound Document
- Csound Orchestra
- Csound Score
- CUDA - Text analysis inherits from C. 
- Cypher