### PR TITLE
D lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -120,7 +120,7 @@
 | CUDA                          |                                     |                    |                    |
 | Cypher                        |                                     |                    |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Darcs Patch                   |                                     |                    |                    |
+| Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DASM16                        |                                     |                    |                    |
 | Debian Control file           |                                     |                    |                    |
 | Devicetree                    |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -124,7 +124,7 @@
 | DASM16                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Debian Control file           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Devicetree                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| dg                            |                                     |                    |                    |
+| dg                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Duel                          |                                     |                    |                    |
 | Dylan session                 |                                     |                    |                    |
 | Dylan                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -119,7 +119,7 @@
 | Csound Score                  |                                     |                    |                    |
 | CUDA                          |                                     |                    |                    |
 | Cypher                        |                                     |                    |                    |
-| d-objdump                     |                                     |                    |                    |
+| d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   |                                     |                    |                    |
 | DASM16                        |                                     |                    |                    |
 | Debian Control file           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -126,7 +126,7 @@
 | Devicetree                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | dg                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Duel                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Dylan session                 |                                     |                    |                    |
+| Dylan session                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan                         |                                     |                    |                    |
 | DylanLID                      |                                     |                    |                    |
 | E-mail                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -122,7 +122,7 @@
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DASM16                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Debian Control file           |                                     |                    |                    |
+| Debian Control file           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Devicetree                    |                                     |                    |                    |
 | dg                            |                                     |                    |                    |
 | Duel                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -123,7 +123,7 @@
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DASM16                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Debian Control file           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Devicetree                    |                                     |                    |                    |
+| Devicetree                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | dg                            |                                     |                    |                    |
 | Duel                          |                                     |                    |                    |
 | Dylan session                 |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -127,7 +127,7 @@
 | dg                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Duel                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan session                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Dylan                         |                                     |                    |                    |
+| Dylan                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DylanLID                      |                                     |                    |                    |
 | E-mail                        |                                     |                    |                    |
 | eC                            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -121,7 +121,7 @@
 | Cypher                        |                                     |                    |                    |
 | d-objdump                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Darcs Patch                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| DASM16                        |                                     |                    |                    |
+| DASM16                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Debian Control file           |                                     |                    |                    |
 | Devicetree                    |                                     |                    |                    |
 | dg                            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -125,7 +125,7 @@
 | Debian Control file           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Devicetree                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | dg                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Duel                          |                                     |                    |                    |
+| Duel                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan session                 |                                     |                    |                    |
 | Dylan                         |                                     |                    |                    |
 | DylanLID                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -128,7 +128,7 @@
 | Duel                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan session                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| DylanLID                      |                                     |                    |                    |
+| DylanLID                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | E-mail                        |                                     |                    |                    |
 | eC                            |                                     |                    |                    |
 | Earl Grey                     |                                     |                    |                    |

--- a/lexers/d/darcspatch.go
+++ b/lexers/d/darcspatch.go
@@ -1,0 +1,18 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// DarcsPatch lexer.
+var DarcsPatch = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Darcs Patch",
+		Aliases:   []string{"dpatch"},
+		Filenames: []string{"*.dpatch", "*.darcspatch"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dasm16.go
+++ b/lexers/d/dasm16.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Dasm16 lexer.
+var Dasm16 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "DASM16",
+		Aliases:   []string{"dasm16"},
+		Filenames: []string{"*.dasm16", "*.dasm"},
+		MimeTypes: []string{"text/x-dasm16"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/debiancontrol.go
+++ b/lexers/d/debiancontrol.go
@@ -1,0 +1,18 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// DebianControl lexer.
+var DebianControl = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Debian Control file",
+		Aliases:   []string{"control", "debcontrol"},
+		Filenames: []string{"control"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/devicetree.go
+++ b/lexers/d/devicetree.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Devicetree lexer.
+var Devicetree = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Devicetree",
+		Aliases:   []string{"devicetree", "dts"},
+		Filenames: []string{"*.dts", "*.dtsi"},
+		MimeTypes: []string{"text/x-c"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dg.go
+++ b/lexers/d/dg.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Dg lexer.
+var Dg = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "dg",
+		Aliases:   []string{"dg"},
+		Filenames: []string{"*.dg"},
+		MimeTypes: []string{"text/x-dg"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dobjdump.go
+++ b/lexers/d/dobjdump.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// DObjdump lexer.
+var DObjdump = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "d-objdump",
+		Aliases:   []string{"d-objdump"},
+		Filenames: []string{"*.d-objdump"},
+		MimeTypes: []string{"text/x-d-objdump"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/duel.go
+++ b/lexers/d/duel.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Duel lexer.
+var Duel = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Duel",
+		Aliases:   []string{"duel", "jbst", "jsonml+bst"},
+		Filenames: []string{"*.duel", "*.jbst"},
+		MimeTypes: []string{"text/x-duel", "text/x-jbst"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dylan.go
+++ b/lexers/d/dylan.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Dylan lexer.
+var Dylan = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Dylan",
+		Aliases:   []string{"dylan"},
+		Filenames: []string{"*.dylan", "*.dyl", "*.intr"},
+		MimeTypes: []string{"text/x-dylan"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dylanconsole.go
+++ b/lexers/d/dylanconsole.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// DylanConsole lexer.
+var DylanConsole = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Dylan session",
+		Aliases:   []string{"dylan-console", "dylan-repl"},
+		Filenames: []string{"*.dylan-console"},
+		MimeTypes: []string{"text/x-dylan-console"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/d/dylanlid.go
+++ b/lexers/d/dylanlid.go
@@ -1,0 +1,19 @@
+package d
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// DylanLid lexer.
+var DylanLid = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "DylanLID",
+		Aliases:   []string{"dylan-lid", "lid"},
+		Filenames: []string{"*.lid", "*.hdp"},
+		MimeTypes: []string{"text/x-dylan-lid"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `d` package lexers.

- d-objdump
- Darcs Patch
- DASM16
- Debian Control
- Devicetree
- dg
- Duel
- Dylan Console
- Dylan
- DylanLID