### PR TITLE
Http lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -165,7 +165,7 @@
 | HSAIL                         |                                     |                    |                    |
 | Hspec                         |                                     |                    |                    |
 | HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| HTTP                          |  Lexer exists in chroma             | :heavy_check_mark: |                    |
+| HTTP                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Hxml                          |                                     |                    |                    |
 | Hy                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Hybris                        |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/h/http.go
+++ b/lexers/h/http.go
@@ -31,7 +31,28 @@ var HTTP = internal.Register(httpBodyContentTypeLexer(MustNewLexer(
 			{`.+`, EmitterFunc(httpContentBlock), nil},
 		},
 	},
-)))
+).SetAnalyser(func(text string) float32 {
+	if strings.HasPrefix(text, "GET") ||
+		strings.HasPrefix(text, "POST") ||
+		strings.HasPrefix(text, "PUT") ||
+		strings.HasPrefix(text, "DELETE") ||
+		strings.HasPrefix(text, "HEAD") ||
+		strings.HasPrefix(text, "OPTIONS") ||
+		strings.HasPrefix(text, "TRACE") ||
+		strings.HasPrefix(text, "PATCH") {
+		return 1.0
+	}
+
+	return 0
+})))
+
+func (d *httpBodyContentTyper) AnalyseText(text string) float32 {
+	if analyser, ok := d.Lexer.(Analyser); ok {
+		return analyser.AnalyseText(text)
+	}
+
+	return 0
+}
 
 func httpContentBlock(groups []string, lexer Lexer) Iterator {
 	tokens := []Token{

--- a/lexers/h/http_test.go
+++ b/lexers/h/http_test.go
@@ -1,0 +1,20 @@
+package h_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/h"
+)
+
+func TestHTTP_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/http_request.http")
+	assert.NoError(t, err)
+
+	analyser, ok := h.HTTP.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/h/testdata/http_request.http
+++ b/lexers/h/testdata/http_request.http
@@ -1,0 +1,15 @@
+POST /demo/submit/ HTTP/1.1
+Host: pygments.org
+Connection: keep-alivk
+Cache-Control: max-age=0
+Origin: http://pygments.org
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2)
+    AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7
+Content-Type: application/x-www-form-urlencoded
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+Referer: http://pygments.org/
+Accept-Encoding: gzip,deflate,sdch
+Accept-Language: en-US,en;q=0.8
+Accept-Charset: windows-949,utf-8;q=0.7,*;q=0.3
+
+name=test&lang=text&code=asdf&user=


### PR DESCRIPTION
this PR ports pygments HTTP text analysis to chroma/go. Original code can be found at: https://github.com/pygments/pygments/blob/master/pygments/lexers/textfmts.py#L197.

A new method called `AnalyseText` has been added to bypass the original lexer. Thanks @dron22 