### PR TITLE
E lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -137,7 +137,7 @@
 | Earl Grey                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Easytrieve                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Eiffel                        |                                     |                    |                    |
+| Eiffel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Elixir iex session            |                                     |                    |                    |
 | EmacsLisp                     |  Lexer exists in chroma             | :heavy_check_mark: |                    |
 | ERB                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -143,7 +143,7 @@
 | ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Erlang erl session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Evoque                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| execline                      |                                     | :heavy_check_mark: |                    |
+| execline                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -133,7 +133,7 @@
 | Dylan                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DylanLID                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | E-mail                        |                                     |                    |                    |
-| eC                            |                                     | :heavy_check_mark: |                    |
+| eC                            | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
 | Earl Grey                     |                                     |                    |                    |
 | Easytrieve                    |                                     |                    |                    |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -141,7 +141,7 @@
 | Elixir iex session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | EmacsLisp                     | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Erlang erl session            |                                     |                    |                    |
+| Erlang erl session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Evoque                        |                                     |                    |                    |
 | execline                      |                                     |                    |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -133,7 +133,7 @@
 | Dylan                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DylanLID                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | E-mail                        |                                     |                    |                    |
-| eC                            |                                     |                    |                    |
+| eC                            |                                     | :heavy_check_mark: |                    |
 | Earl Grey                     |                                     |                    |                    |
 | Easytrieve                    |                                     |                    |                    |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -134,7 +134,7 @@
 | DylanLID                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | E-mail                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | eC                            | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
-| Earl Grey                     |                                     |                    |                    |
+| Earl Grey                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Easytrieve                    |                                     |                    |                    |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Eiffel                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -135,7 +135,7 @@
 | E-mail                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | eC                            | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
 | Earl Grey                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Easytrieve                    |                                     |                    |                    |
+| Easytrieve                    |                                     | :heavy_check_mark: |                    |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Eiffel                        |                                     |                    |                    |
 | Elixir iex session            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -142,7 +142,7 @@
 | EmacsLisp                     | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Erlang erl session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Evoque                        |                                     | :heavy_check_mark: |                    |
+| Evoque                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | execline                      |                                     |                    |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -135,7 +135,7 @@
 | E-mail                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | eC                            | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
 | Earl Grey                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Easytrieve                    |                                     | :heavy_check_mark: |                    |
+| Easytrieve                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Eiffel                        |                                     |                    |                    |
 | Elixir iex session            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -132,7 +132,7 @@
 | Dylan session                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Dylan                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | DylanLID                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| E-mail                        |                                     |                    |                    |
+| E-mail                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | eC                            | Text analysis inherits from C.      | :heavy_check_mark: | :heavy_check_mark: |
 | Earl Grey                     |                                     |                    |                    |
 | Easytrieve                    |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -142,7 +142,7 @@
 | EmacsLisp                     | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Erlang erl session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Evoque                        |                                     |                    |                    |
+| Evoque                        |                                     | :heavy_check_mark: |                    |
 | execline                      |                                     |                    |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -138,8 +138,8 @@
 | Easytrieve                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | ECL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Eiffel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Elixir iex session            |                                     |                    |                    |
-| EmacsLisp                     |  Lexer exists in chroma             | :heavy_check_mark: |                    |
+| Elixir iex session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| EmacsLisp                     | Lexer exists in chroma              | :heavy_check_mark: |                    |
 | ERB                           |                                     |                    |                    |
 | Erlang erl session            |                                     |                    |                    |
 | Evoque                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -140,7 +140,7 @@
 | Eiffel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Elixir iex session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | EmacsLisp                     | Lexer exists in chroma              | :heavy_check_mark: |                    |
-| ERB                           |                                     |                    |                    |
+| ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Erlang erl session            |                                     |                    |                    |
 | Evoque                        |                                     |                    |                    |
 | execline                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -143,7 +143,7 @@
 | ERB                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Erlang erl session            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Evoque                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| execline                      |                                     |                    |                    |
+| execline                      |                                     | :heavy_check_mark: |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/e/earlgrey.go
+++ b/lexers/e/earlgrey.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// EarlGrey lexer.
+var EarlGrey = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Earl Grey",
+		Aliases:   []string{"earl-grey", "earlgrey", "eg"},
+		Filenames: []string{"*.eg"},
+		MimeTypes: []string{"text/x-earl-grey"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/easytrieve.go
+++ b/lexers/e/easytrieve.go
@@ -71,31 +71,29 @@ var Easytrieve = internal.Register(MustNewLexer(
 			continue
 		}
 
-		firstWord := string(splitted[0])
-
-		if !hasReport && !hasJob && !hasFile && !hasParm && firstWord == "PARM" {
+		if !hasReport && !hasJob && !hasFile && !hasParm && splitted[0] == "PARM" {
 			hasParm = true
 		}
 
-		if !hasReport && !hasJob && !hasFile && firstWord == "FILE" {
+		if !hasReport && !hasJob && !hasFile && splitted[0] == "FILE" {
 			hasFile = true
 		}
 
-		if !hasReport && !hasJob && firstWord == "JOB" {
+		if !hasReport && !hasJob && splitted[0] == "JOB" {
 			hasJob = true
 		}
 
-		if !hasReport && firstWord == "PROC" {
+		if !hasReport && splitted[0] == "PROC" {
 			hasProc = true
 			continue
 		}
 
-		if !hasReport && firstWord == "END-PROC" {
+		if !hasReport && splitted[0] == "END-PROC" {
 			hasEndProc = true
 			continue
 		}
 
-		if !hasReport && firstWord == "REPORT" {
+		if !hasReport && splitted[0] == "REPORT" {
 			hasReport = true
 		}
 	}

--- a/lexers/e/easytrieve.go
+++ b/lexers/e/easytrieve.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Easytrieve lexer.
+var Easytrieve = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Easytrieve",
+		Aliases:   []string{"easytrieve"},
+		Filenames: []string{"*.ezt", "*.mac"},
+		MimeTypes: []string{"text/x-easytrieve"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/easytrieve.go
+++ b/lexers/e/easytrieve.go
@@ -1,8 +1,16 @@
 package e
 
 import (
+	"regexp"
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	easytrieveAnalyserCommetLineRe  = regexp.MustCompile(`^\s*\*`)
+	easytrieveAnalyserMacroHeaderRe = regexp.MustCompile(`\s*MACRO`)
 )
 
 // Easytrieve lexer.
@@ -16,4 +24,114 @@ var Easytrieve = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Perform a structural analysis for basic Easytrieve constructs.
+	var (
+		result           float32
+		hasEndProc       bool
+		hasHeaderComment bool
+		hasFile          bool
+		hasJob           bool
+		hasProc          bool
+		hasParm          bool
+		hasReport        bool
+	)
+
+	lines := strings.Split(text, "\n")
+
+	// Remove possible empty lines and header comments.
+	for range lines {
+		if len(strings.TrimSpace(lines[0])) > 0 && !easytrieveAnalyserCommetLineRe.MatchString(lines[0]) {
+			break
+		}
+
+		if easytrieveAnalyserCommetLineRe.MatchString(text) {
+			hasHeaderComment = true
+		}
+
+		lines = lines[1:]
+	}
+
+	if easytrieveAnalyserMacroHeaderRe.MatchString(lines[0]) {
+		// Looks like an Easytrieve macro.
+		result += 0.4
+
+		if hasHeaderComment {
+			result += 0.4
+		}
+
+		return result
+	}
+
+	// Scan the source for lines starting with indicators.
+	for _, line := range lines {
+		splitted := strings.Fields(line)
+
+		if len(splitted) < 2 {
+			continue
+		}
+
+		firstWord := string(splitted[0])
+
+		if !hasReport && !hasJob && !hasFile && !hasParm && firstWord == "PARM" {
+			hasParm = true
+		}
+
+		if !hasReport && !hasJob && !hasFile && firstWord == "FILE" {
+			hasFile = true
+		}
+
+		if !hasReport && !hasJob && firstWord == "JOB" {
+			hasJob = true
+		}
+
+		if !hasReport && firstWord == "PROC" {
+			hasProc = true
+			continue
+		}
+
+		if !hasReport && firstWord == "END-PROC" {
+			hasEndProc = true
+			continue
+		}
+
+		if !hasReport && firstWord == "REPORT" {
+			hasReport = true
+		}
+	}
+
+	// Weight the findings.
+	if hasJob && hasProc == hasEndProc && hasHeaderComment {
+		result += 0.1
+	}
+
+	if hasJob && hasProc == hasEndProc && hasParm && hasProc {
+		// Found PARM, JOB and PROC/END-PROC:
+		// pretty sure this is Easytrieve.
+		result += 0.8
+
+		return result
+	}
+
+	if hasJob && hasProc == hasEndProc && hasParm && !hasProc {
+		// Found PARAM and JOB: probably this is Easytrieve.
+		result += 0.5
+
+		return result
+	}
+
+	if hasJob && hasProc == hasEndProc && !hasParm {
+		// Found JOB and possibly other keywords: might be Easytrieve.
+		result += 0.11
+	}
+
+	if hasJob && hasProc == hasEndProc && !hasParm && hasFile {
+		result += 0.01
+	}
+
+	if hasJob && hasProc == hasEndProc && !hasParm && hasReport {
+		result += 0.01
+	}
+
+	return result
+}))

--- a/lexers/e/easytrieve_test.go
+++ b/lexers/e/easytrieve_test.go
@@ -1,0 +1,39 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
+)
+
+func TestEasytrieve_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"basic": {
+			Filepath: "testdata/easytrieve_basic.ezt",
+			Expected: 0.6,
+		},
+		"macro": {
+			Filepath: "testdata/easytrieve_macro.mac",
+			Expected: 0.8,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := e.Easytrieve.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/e/ec.go
+++ b/lexers/e/ec.go
@@ -1,7 +1,9 @@
 package e
 
 import (
+	"github.com/alecthomas/chroma"
 	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/c"
 	"github.com/alecthomas/chroma/lexers/internal"
 )
 
@@ -16,4 +18,10 @@ var Ec = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if analyser, ok := c.C.(chroma.Analyser); ok {
+		return analyser.AnalyseText(text)
+	}
+
+	return 0
+}))

--- a/lexers/e/ec.go
+++ b/lexers/e/ec.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Ec lexer.
+var Ec = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "eC",
+		Aliases:   []string{"ec"},
+		Filenames: []string{"*.ec", "*.eh"},
+		MimeTypes: []string{"text/x-echdr", "text/x-ecsrc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/ec_test.go
+++ b/lexers/e/ec_test.go
@@ -1,0 +1,43 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/c"
+)
+
+func TestEc_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"include": {
+			Filepath: "testdata/ec_include.ec",
+			Expected: 0.1,
+		},
+		"ifdef": {
+			Filepath: "testdata/ec_ifdef.ec",
+			Expected: 0.1,
+		},
+		"ifndef": {
+			Filepath: "testdata/ec_ifndef.ec",
+			Expected: 0.1,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := c.C.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/e/eiffel.go
+++ b/lexers/e/eiffel.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Eiffel lexer.
+var Eiffel = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Eiffel",
+		Aliases:   []string{"eiffel"},
+		Filenames: []string{"*.e"},
+		MimeTypes: []string{"text/x-eiffel"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/elixirconsole.go
+++ b/lexers/e/elixirconsole.go
@@ -1,0 +1,18 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ElixirConsole lexer.
+var ElixirConsole = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Elixir iex session",
+		Aliases:   []string{"iex"},
+		MimeTypes: []string{"text/x-elixir-shellsession"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/email.go
+++ b/lexers/e/email.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Email lexer.
+var Email = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "E-mail",
+		Aliases:   []string{"email", "eml"},
+		Filenames: []string{"*.eml"},
+		MimeTypes: []string{"message/rfc822"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/erb.go
+++ b/lexers/e/erb.go
@@ -1,6 +1,8 @@
 package e
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -15,4 +17,10 @@ var Erb = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, "<%") && strings.Contains(text, "%>") {
+		return 0.4
+	}
+
+	return 0
+}))

--- a/lexers/e/erb.go
+++ b/lexers/e/erb.go
@@ -1,0 +1,18 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Erb lexer.
+var Erb = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ERB",
+		Aliases:   []string{"erb"},
+		MimeTypes: []string{"application/x-ruby-templating"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/erb_test.go
+++ b/lexers/e/erb_test.go
@@ -1,0 +1,20 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
+)
+
+func TestErb_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/erb_basic.erb")
+	assert.NoError(t, err)
+
+	analyser, ok := e.Erb.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.4), analyser.AnalyseText(string(data)))
+}

--- a/lexers/e/erlangshell.go
+++ b/lexers/e/erlangshell.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ErlangShell lexer.
+var ErlangShell = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Erlang erl session",
+		Aliases:   []string{"erl"},
+		Filenames: []string{"*.erl-sh"},
+		MimeTypes: []string{"text/x-erl-shellsession"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/evoque.go
+++ b/lexers/e/evoque.go
@@ -1,6 +1,8 @@
 package e
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,11 @@ var Evoque = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// Evoque templates use $evoque, which is unique.
+	if strings.Contains(text, "$evoque") {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/e/evoque.go
+++ b/lexers/e/evoque.go
@@ -1,0 +1,19 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Evoque lexer.
+var Evoque = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Evoque",
+		Aliases:   []string{"evoque"},
+		Filenames: []string{"*.evoque"},
+		MimeTypes: []string{"application/x-evoque"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/evoque_test.go
+++ b/lexers/e/evoque_test.go
@@ -1,0 +1,20 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
+)
+
+func TestEvoque_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/evoque_basic.evoque")
+	assert.NoError(t, err)
+
+	analyser, ok := e.Evoque.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/e/execline.go
+++ b/lexers/e/execline.go
@@ -1,0 +1,18 @@
+package e
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Execline lexer.
+var Execline = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "execline",
+		Aliases:   []string{"execline"},
+		Filenames: []string{"*.exec"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/e/execline.go
+++ b/lexers/e/execline.go
@@ -3,6 +3,7 @@ package e
 import (
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/shebang"
 )
 
 // Execline lexer.
@@ -15,4 +16,10 @@ var Execline = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if matched, _ := shebang.MatchString(text, "execlineb"); matched {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/e/execline_test.go
+++ b/lexers/e/execline_test.go
@@ -1,0 +1,20 @@
+package e_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/e"
+)
+
+func TestExecline_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/execline_shebang.exec")
+	assert.NoError(t, err)
+
+	analyser, ok := e.Execline.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/e/testdata/easytrieve_basic.ezt
+++ b/lexers/e/testdata/easytrieve_basic.ezt
@@ -1,0 +1,32 @@
+* Easytrieve Plus example programm.
+
+* Environtment section.
+PARM DEBUG(FLOW FLDCHK)
+
+* Library Section.
+FILE PERSNL FB(150 1800)
+  NAME  17 8 A
+  EMP#   9 5 N * Note: '#' is a valid character for names.
+  DEPT  98 3 N. GROSS 94 4 P 2
+  *           ^ 2 field definitions in 1 line.
+
+* Call macro in example.mac.
+FILE EXAMPLE FB(80 200)
+%EXAMPLE SOMEFILE SOME
+
+* Activity Section.
+JOB INPUT PERSNL NAME FIRST-PROGRAM START AT-START FINISH AT_FINISH
+  PRINT PAY-RPT
+REPORT PAY-RPT LINESIZE 80
+  TITLE 01 'PERSONNEL REPORT EXAMPLE-1'
+  LINE 01 DEPT NAME EMP# GROSS
+
+* Procedure declarations.
+AT-START. PROC
+  DISPLAY 'PROCESSING...'
+END-PROC
+
+AT-FINISH
+PROC
+  DISPLAY 'DONE.'
+END-PROC

--- a/lexers/e/testdata/easytrieve_macro.mac
+++ b/lexers/e/testdata/easytrieve_macro.mac
@@ -1,0 +1,6 @@
+* Example Easytrieve macro declaration. For an example on calling this
+* macro, see example.ezt.
+MACRO FILENAME PREFIX
+&FILENAME.
+&PREFIX.-LINE 1 80 A
+&PREFIX.-KEY  1  8 A

--- a/lexers/e/testdata/ec_ifdef.ec
+++ b/lexers/e/testdata/ec_ifdef.ec
@@ -1,0 +1,2 @@
+
+#ifdef DEBUG

--- a/lexers/e/testdata/ec_ifndef.ec
+++ b/lexers/e/testdata/ec_ifndef.ec
@@ -1,0 +1,2 @@
+
+#ifndef DEBUG

--- a/lexers/e/testdata/ec_include.ec
+++ b/lexers/e/testdata/ec_include.ec
@@ -1,0 +1,2 @@
+
+#include <GL/gl.h>

--- a/lexers/e/testdata/erb_basic.erb
+++ b/lexers/e/testdata/erb_basic.erb
@@ -1,0 +1,1 @@
+<%# Non-printing tag ↓ -%>

--- a/lexers/e/testdata/evoque_basic.evoque
+++ b/lexers/e/testdata/evoque_basic.evoque
@@ -1,0 +1,1 @@
+$evoque{disclaimer, collection="legals"}

--- a/lexers/e/testdata/execline_shebang.exec
+++ b/lexers/e/testdata/execline_shebang.exec
@@ -1,0 +1,1 @@
+#!/usr/bin/execlineb


### PR DESCRIPTION
This PR adds missing `e` package lexers.

- eC
- E-mail
- Earl Grey
- Easytrieve - All nested "ifs" from legacy code were fixed in this porting.
- Eiffel
- Elixir iex session
- ERB
- Erlang erl session
- Evoque
- execline

Fixes https://github.com/wakatime/wakatime-cli/issues/204