### PR TITLE
F lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -153,7 +153,7 @@
 | Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FortranFixed                  |                                     |                    |                    |
+| FortranFixed                  | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FoxPro                        |                                     |                    |                    |
 | Freefem                       |                                     |                    |                    |
 | GAP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -152,7 +152,7 @@
 | Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FloScript                     |                                     |                    |                    |
+| FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FortranFixed                  |                                     |                    |                    |
 | FoxPro                        |                                     |                    |                    |
 | Freefem                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -154,7 +154,7 @@
 | Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FortranFixed                  | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FoxPro                        |                                     |                    |                    |
+| FoxPro                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Freefem                       |                                     |                    |                    |
 | GAP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | GAS                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -148,7 +148,7 @@
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fancy                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Fantom                        |                                     |                    |                    |
+| Fantom                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Felix                         |                                     |                    |                    |
 | Fennel                        |                                     |                    |                    |
 | Flatline                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -151,7 +151,7 @@
 | Fantom                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Flatline                      |                                     |                    |                    |
+| Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FloScript                     |                                     |                    |                    |
 | FortranFixed                  |                                     |                    |                    |
 | FoxPro                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -149,7 +149,7 @@
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fancy                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fantom                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Felix                         |                                     |                    |                    |
+| Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Fennel                        |                                     |                    |                    |
 | Flatline                      |                                     |                    |                    |
 | FloScript                     |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -150,7 +150,7 @@
 | Fancy                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fantom                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Fennel                        |                                     |                    |                    |
+| Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | Flatline                      |                                     |                    |                    |
 | FloScript                     |                                     |                    |                    |
 | FortranFixed                  |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -147,7 +147,7 @@
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Fancy                         |                                     |                    |                    |
+| Fancy                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fantom                        |                                     |                    |                    |
 | Felix                         |                                     |                    |                    |
 | Fennel                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -155,7 +155,7 @@
 | FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FortranFixed                  | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | FoxPro                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Freefem                       |                                     |                    |                    |
+| Freefem                       | No text analysis exists in pygments | :heavy_check_mark: |                    |``
 | GAP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | GAS                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | GDScript                      |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -146,7 +146,7 @@
 | execline                      |                                     |                    |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| FStar                         |                                     |                    |                    |
+| FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fancy                         |                                     |                    |                    |
 | Fantom                        |                                     |                    |                    |
 | Felix                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -145,7 +145,7 @@
 | Evoque                        |                                     |                    |                    |
 | execline                      |                                     |                    |                    |
 | Ezhil                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| F#                            |                                     |                    |                    |
+| F#                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | FStar                         |                                     |                    |                    |
 | Fancy                         |                                     |                    |                    |
 | Fantom                        |                                     |                    |                    |

--- a/lexers/f/fancy.go
+++ b/lexers/f/fancy.go
@@ -1,0 +1,19 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Fancy lexer.
+var Fancy = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Fancy",
+		Aliases:   []string{"fancy", "fy"},
+		Filenames: []string{"*.fy", "*.fancypack"},
+		MimeTypes: []string{"text/x-fancysrc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/fantom.go
+++ b/lexers/f/fantom.go
@@ -1,0 +1,19 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Fantom lexer.
+var Fantom = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Fantom",
+		Aliases:   []string{"fan"},
+		Filenames: []string{"*.fan"},
+		MimeTypes: []string{"application/x-fantom"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/felix.go
+++ b/lexers/f/felix.go
@@ -1,0 +1,19 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Felix lexer.
+var Felix = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Felix",
+		Aliases:   []string{"felix", "flx"},
+		Filenames: []string{"*.flx", "*.flxh"},
+		MimeTypes: []string{"text/x-felix"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/fennel.go
+++ b/lexers/f/fennel.go
@@ -1,0 +1,18 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Fennel lexer.
+var Fennel = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Fennel",
+		Aliases:   []string{"fennel", "fnl"},
+		Filenames: []string{"*.fnl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/flatline.go
+++ b/lexers/f/flatline.go
@@ -1,0 +1,18 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Flatline lexer.
+var Flatline = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Flatline",
+		Aliases:   []string{"flatline"},
+		MimeTypes: []string{"text/x-flatline"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/floscript.go
+++ b/lexers/f/floscript.go
@@ -1,0 +1,18 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// FloScript lexer.
+var FloScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "FloScript",
+		Aliases:   []string{"floscript", "flo"},
+		Filenames: []string{"*.flo"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/fortranfixed.go
+++ b/lexers/f/fortranfixed.go
@@ -1,0 +1,18 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// FortranFixed lexer.
+var FortranFixed = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "FortranFixed",
+		Aliases:   []string{"fortranfixed"},
+		Filenames: []string{"*.f", "*.F"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/foxpro.go
+++ b/lexers/f/foxpro.go
@@ -1,0 +1,18 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// FoxPro lexer.
+var FoxPro = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "FoxPro",
+		Aliases:   []string{"foxpro", "vfp", "clipper", "xbase"},
+		Filenames: []string{"*.PRG", "*.prg"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/freefem.go
+++ b/lexers/f/freefem.go
@@ -1,0 +1,19 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Freefem lexer.
+var Freefem = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Freefem",
+		Aliases:   []string{"freefem"},
+		Filenames: []string{"*.edp"},
+		MimeTypes: []string{"text/x-freefem"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/f/fstar.go
+++ b/lexers/f/fstar.go
@@ -1,0 +1,19 @@
+package f
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// FStar lexer.
+var FStar = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "FStar",
+		Aliases:   []string{"fstar"},
+		Filenames: []string{"*.fst", "*.fsti"},
+		MimeTypes: []string{"text/x-fstar"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `f` package lexers.

- FStar
- Fancy
- Fantom
- Felix
- Fennel
- Flatline
- FloScript
- FortranFixed
- FoxPro
- Freefem

Fixes https://github.com/wakatime/wakatime-cli/issues/205