### PR TITLE
Z lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -341,7 +341,7 @@
 | Xtend                         |                                     |                    |                    |
 | xtlang                        |                                     |                    |                    |
 | Zeek                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Zephir                        |                                     |                    |                    |
+| Zephir                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 
 ## Missing file extension support
 

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -340,7 +340,7 @@
 | XSLT                          |                                     |                    |                    |
 | Xtend                         |                                     |                    |                    |
 | xtlang                        |                                     |                    |                    |
-| Zeek                          |                                     |                    |                    |
+| Zeek                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Zephir                        |                                     |                    |                    |
 
 ## Missing file extension support

--- a/lexers/z/zeek.go
+++ b/lexers/z/zeek.go
@@ -1,0 +1,18 @@
+package z
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Zeek lexer.
+var Zeek = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Zeek",
+		Aliases:   []string{"zeek", "bro"},
+		Filenames: []string{"*.zeek", "*.bro"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/z/zephir.go
+++ b/lexers/z/zephir.go
@@ -1,0 +1,18 @@
+package z
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Zephir lexer.
+var Zephir = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Zephir",
+		Aliases:   []string{"zephir"},
+		Filenames: []string{"*.zep"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `z` package lexers.

- Zeek (https://github.com/pygments/pygments/blob/master/pygments/lexers/dsls.py#L191)
- Zephir (https://github.com/pygments/pygments/blob/master/pygments/lexers/php.py#L25)

Closes https://github.com/wakatime/wakatime-cli/issues/224
