### PR TITLE
X lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -337,7 +337,7 @@
 | Whiley                        |                                     |                    |                    |
 | X10                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XQuery                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| XSLT                          |                                     |                    |                    |
+| XSLT                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Xtend                         |                                     |                    |                    |
 | xtlang                        |                                     |                    |                    |
 | Zeek                          | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -335,7 +335,7 @@
 | WDiff                         |                                     |                    |                    |
 | Web IDL                       |                                     |                    |                    |
 | Whiley                        |                                     |                    |                    |
-| X10                           |                                     |                    |                    |
+| X10                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XQuery                        |                                     |                    |                    |
 | XSLT                          |                                     |                    |                    |
 | Xtend                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -336,7 +336,7 @@
 | Web IDL                       |                                     |                    |                    |
 | Whiley                        |                                     |                    |                    |
 | X10                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| XQuery                        |                                     |                    |                    |
+| XQuery                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XSLT                          |                                     |                    |                    |
 | Xtend                         |                                     |                    |                    |
 | xtlang                        |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -339,7 +339,7 @@
 | XQuery                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XSLT                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Xtend                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| xtlang                        |                                     |                    |                    |
+| xtlang                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Zeek                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Zephir                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -338,7 +338,7 @@
 | X10                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XQuery                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | XSLT                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Xtend                         |                                     |                    |                    |
+| Xtend                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | xtlang                        |                                     |                    |                    |
 | Zeek                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Zephir                        | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/x/testdata/xslt.xsl
+++ b/lexers/x/testdata/xslt.xsl
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text"/>
+
+  <xsl:template match="/">
+    Article - <xsl:value-of select="/Article/Title"/>
+    Authors: <xsl:apply-templates select="/Article/Authors/Author"/>
+  </xsl:template>
+
+  <xsl:template match="Author">
+    - <xsl:value-of select="." />
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/lexers/x/x10.go
+++ b/lexers/x/x10.go
@@ -1,0 +1,19 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// X10 lexer.
+var X10 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "X10",
+		Aliases:   []string{"x10", "xten"},
+		Filenames: []string{"*.x10"},
+		MimeTypes: []string{"text/x-x10"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/x/xquery.go
+++ b/lexers/x/xquery.go
@@ -1,0 +1,19 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// XQuery lexer.
+var XQuery = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "XQuery",
+		Aliases:   []string{"xquery", "xqy", "xq", "xql", "xqm"},
+		Filenames: []string{"*.xqy", "*.xquery", "*.xq", "*.xql", "*.xqm"},
+		MimeTypes: []string{"text/xquery", "application/xquery"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/x/xslt.go
+++ b/lexers/x/xslt.go
@@ -1,8 +1,11 @@
 package x
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/xml"
 )
 
 // XSLT lexer.
@@ -17,4 +20,10 @@ var XSLT = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if xml.MatchString(text) && strings.Contains(text, "<xsl") {
+		return 0.8
+	}
+
+	return 0
+}))

--- a/lexers/x/xslt_test.go
+++ b/lexers/x/xslt_test.go
@@ -1,0 +1,20 @@
+package x_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/x"
+)
+
+func TestXSLT_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/xslt.xsl")
+	assert.NoError(t, err)
+
+	analyser, ok := x.XSLT.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.8), analyser.AnalyseText(string(data)))
+}

--- a/lexers/x/xtend.go
+++ b/lexers/x/xtend.go
@@ -1,0 +1,19 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Xtend lexer.
+var Xtend = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Xtend",
+		Aliases:   []string{"xtend"},
+		Filenames: []string{"*.xtend"},
+		MimeTypes: []string{"text/x-xtend"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/x/xtlang.go
+++ b/lexers/x/xtlang.go
@@ -1,0 +1,18 @@
+package x
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Xtlang lexer.
+var Xtlang = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "xtlang",
+		Aliases:   []string{"extempore"},
+		Filenames: []string{"*.xtm"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `x` package lexers.

- X10 (https://github.com/pygments/pygments/blob/master/pygments/lexers/x10.py#L20)
- XQuery (https://github.com/pygments/pygments/blob/master/pygments/lexers/webmisc.py#L60)
- XSLT (text analysis: https://github.com/pygments/pygments/blob/master/pygments/lexers/html.py#L279)
- Xtend (https://github.com/pygments/pygments/blob/master/pygments/lexers/jvm.py#L1112)
- xtlang (https://github.com/pygments/pygments/blob/master/pygments/lexers/lisp.py#L2419)

Closes https://github.com/wakatime/wakatime-cli/issues/223