### PR TITLE
V lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -330,7 +330,8 @@
 | VCTreeStatus                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VGL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| vhdl                          |                                     |                    |                    |
+| vhdl                          | Different name in chroma "VHDL"!    | :heavy_check_mark: |                    |
+|                               | No text analysis exists in pygments |                    |                    |
 | WDiff                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Web IDL                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Whiley                        | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -324,12 +324,12 @@
 | Unicon                        |                                     |                    |                    |
 | UrbiScript                    |                                     |                    |                    |
 | USD                           |                                     |                    |                    |
+| Vala                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCLSnippets                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCTreeStatus                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VGL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Vala                          |                                     |                    |                    |
 | vhdl                          |                                     |                    |                    |
 | WDiff                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Web IDL                       | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -326,7 +326,7 @@
 | USD                           |                                     |                    |                    |
 | VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCLSnippets                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| VCTreeStatus                  |                                     |                    |                    |
+| VCTreeStatus                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VGL                           |                                     |                    |                    |
 | Vala                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -324,7 +324,7 @@
 | Unicon                        |                                     |                    |                    |
 | UrbiScript                    |                                     |                    |                    |
 | USD                           |                                     |                    |                    |
-| VBScript                      |                                     |                    |                    |
+| VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCLSnippets                   |                                     |                    |                    |
 | VCTreeStatus                  |                                     |                    |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -325,7 +325,7 @@
 | UrbiScript                    |                                     |                    |                    |
 | USD                           |                                     |                    |                    |
 | VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| VCLSnippets                   |                                     |                    |                    |
+| VCLSnippets                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCTreeStatus                  |                                     |                    |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VGL                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -324,7 +324,6 @@
 | Unicon                        |                                     |                    |                    |
 | UrbiScript                    |                                     |                    |                    |
 | USD                           |                                     |                    |                    |
-| VB.net                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VBScript                      |                                     |                    |                    |
 | VCLSnippets                   |                                     |                    |                    |
 | VCTreeStatus                  |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -328,7 +328,7 @@
 | VCLSnippets                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCTreeStatus                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| VGL                           |                                     |                    |                    |
+| VGL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Vala                          |                                     |                    |                    |
 | vhdl                          |                                     |                    |                    |
 | WDiff                         | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/v/vala.go
+++ b/lexers/v/vala.go
@@ -1,0 +1,19 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Vala lexer.
+var Vala = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Vala",
+		Aliases:   []string{"vala", "vapi"},
+		Filenames: []string{"*.vala", "*.vapi"},
+		MimeTypes: []string{"text/x-vala"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/v/vbscript.go
+++ b/lexers/v/vbscript.go
@@ -1,0 +1,18 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// VBScript lexer.
+var VBScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "VBScript",
+		Aliases:   []string{"vbscript"},
+		Filenames: []string{"*.vbs", "*.VBS"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/v/vclsnippet.go
+++ b/lexers/v/vclsnippet.go
@@ -1,0 +1,18 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// VCLSnippets lexer.
+var VCLSnippets = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "VCLSnippets",
+		Aliases:   []string{"vclsnippets", "vclsnippet"},
+		MimeTypes: []string{"text/x-vclsnippet"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/v/vctreestatus.go
+++ b/lexers/v/vctreestatus.go
@@ -1,0 +1,17 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// VCTreeStatus lexer.
+var VCTreeStatus = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "VCTreeStatus",
+		Aliases: []string{"vctreestatus"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/v/vgl.go
+++ b/lexers/v/vgl.go
@@ -1,0 +1,18 @@
+package v
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// VGL lexer.
+var VGL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "VGL",
+		Aliases:   []string{"vgl"},
+		Filenames: []string{"*.rpf"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
Port missing `v` lexers to Chroma.

- Vala (https://github.com/pygments/pygments/blob/master/pygments/lexers/c_like.py#L178)
- VBScript (https://github.com/pygments/pygments/blob/master/pygments/lexers/basic.py#L504)
- VCLSnippets (https://github.com/pygments/pygments/blob/master/pygments/lexers/varnish.py#L160)
- VCTreeStatus (https://github.com/pygments/pygments/blob/master/pygments/lexers/console.py#L18)
- VGL (https://github.com/pygments/pygments/blob/master/pygments/lexers/dsls.py#L546)

**Others**

- `VB.net` lexer is already existing and was removed from lexer TODO.
-  `vhdl` lexer is already existing, but has a different name in chroma. This has to be handled in wakatime-cli to ensure consistency with python cli. Issue was created for this: https://github.com/wakatime/wakatime-cli/issues/228

Closes https://github.com/wakatime/wakatime-cli/issues/221