### PR TITLE
H lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -164,7 +164,7 @@
 | GoodData-CL                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Groff                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | HLSL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Haml                          |                                     |                    |                    |
+| Haml                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | HSAIL                         |                                     |                    |                    |
 | Hspec                         |                                     |                    |                    |
 | HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -166,7 +166,7 @@
 | HLSL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Haml                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | HSAIL                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Hspec                         |                                     |                    |                    |
+| Hspec                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | HTTP                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Hxml                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -149,13 +149,13 @@
 | FStar                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fancy                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Fantom                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FortranFixed                  | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| FoxPro                        | No text analysis exists in pygments | :heavy_check_mark: |                    |``
-| Freefem                       | No text analysis exists in pygments | :heavy_check_mark: |                    |``
+| Felix                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| Fennel                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| Flatline                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| FloScript                     | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| FortranFixed                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| FoxPro                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| Freefem                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | GAP                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | GAS                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | GDScript                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
@@ -163,7 +163,7 @@
 | Golo                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | GoodData-CL                   | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Groff                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| HLSL                          |                                     |                    |                    |
+| HLSL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Haml                          |                                     |                    |                    |
 | HSAIL                         |                                     |                    |                    |
 | Hspec                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -165,7 +165,7 @@
 | Groff                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | HLSL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Haml                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| HSAIL                         |                                     |                    |                    |
+| HSAIL                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Hspec                         |                                     |                    |                    |
 | HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | HTTP                          |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -169,7 +169,7 @@
 | Hspec                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | HTML                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | HTTP                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Hxml                          |                                     |                    |                    |
+| Hxml                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Hy                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Hybris                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Icon                          |                                     |                    |                    |

--- a/lexers/h/haml.go
+++ b/lexers/h/haml.go
@@ -1,0 +1,19 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Haml lexer.
+var Haml = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Haml",
+		Aliases:   []string{"haml"},
+		Filenames: []string{"*.haml"},
+		MimeTypes: []string{"text/x-haml"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/h/hlslshader.go
+++ b/lexers/h/hlslshader.go
@@ -1,0 +1,19 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// HlslShader lexer.
+var HlslShader = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "HLSL",
+		Aliases:   []string{"hsls"},
+		Filenames: []string{"*.hlsl", "*.hlsli"},
+		MimeTypes: []string{"text/x-hlsl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/h/hsail.go
+++ b/lexers/h/hsail.go
@@ -1,0 +1,19 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Hsail lexer.
+var Hsail = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "HSAIL",
+		Aliases:   []string{"hsail", "hsa"},
+		Filenames: []string{"*.hsail"},
+		MimeTypes: []string{"text/x-hsail"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/h/hspec.go
+++ b/lexers/h/hspec.go
@@ -1,0 +1,17 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Hspec lexer.
+var Hspec = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "Hspec",
+		Aliases: []string{"hspec"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/h/hxml.go
+++ b/lexers/h/hxml.go
@@ -1,0 +1,18 @@
+package h
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Hxml lexer.
+var Hxml = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Hxml",
+		Aliases:   []string{"haxeml", "hxml"},
+		Filenames: []string{"*.hxml"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `h` package lexers.

- HLSL [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fgraphics.py#L152)
- Haml - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhtml.py#L284)
- HSAIL - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fasm.py#L210)
- Hspec - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L162)
- Hxml - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaxe.py#L898)

Closes https://github.com/wakatime/wakatime-cli/issues/207