### PR TITLE
I lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -179,7 +179,7 @@
 | Inform 6 template             | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Inform 7                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Ioke                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| IRC logs                      |                                     |                    |                    |
+| IRC logs                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Isabelle                      |                                     |                    |                    |
 | JAGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Jasmin                        |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -176,7 +176,7 @@
 | IDL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | INI                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Inform 6                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Inform 6 template             |                                     |                    |                    |
+| Inform 6 template             | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Inform 7                      |                                     |                    |                    |
 | Ioke                          |                                     |                    |                    |
 | IRC logs                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -178,7 +178,7 @@
 | Inform 6                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Inform 6 template             | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Inform 7                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Ioke                          |                                     |                    |                    |
+| Ioke                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | IRC logs                      |                                     |                    |                    |
 | Isabelle                      |                                     |                    |                    |
 | JAGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -172,7 +172,7 @@
 | Hxml                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Hy                            |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Hybris                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Icon                          |                                     |                    |                    |
+| Icon                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | IDL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | INI                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Inform 6                      |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -177,7 +177,7 @@
 | INI                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Inform 6                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Inform 6 template             | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Inform 7                      |                                     |                    |                    |
+| Inform 7                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Ioke                          |                                     |                    |                    |
 | IRC logs                      |                                     |                    |                    |
 | Isabelle                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -180,7 +180,7 @@
 | Inform 7                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Ioke                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | IRC logs                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Isabelle                      |                                     |                    |                    |
+| Isabelle                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | JAGS                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Jasmin                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | JCL                           |                                     |                    |                    |

--- a/lexers/i/icon.go
+++ b/lexers/i/icon.go
@@ -1,0 +1,18 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Icon lexer.
+var Icon = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Icon",
+		Aliases:   []string{"icon"},
+		Filenames: []string{"*.icon", "*.ICON"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/inform6template.go
+++ b/lexers/i/inform6template.go
@@ -1,0 +1,18 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Inform6Template lexer.
+var Inform6Template = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Inform 6 template",
+		Aliases:   []string{"i6t"},
+		Filenames: []string{"*.i6t"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/inform7.go
+++ b/lexers/i/inform7.go
@@ -1,0 +1,18 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Inform7 lexer.
+var Inform7 = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Inform 7",
+		Aliases:   []string{"inform7", "i7"},
+		Filenames: []string{"*.ni", "*.i7x"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/ioke.go
+++ b/lexers/i/ioke.go
@@ -1,0 +1,19 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Ioke lexer.
+var Ioke = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Ioke",
+		Aliases:   []string{"ioke", "ik"},
+		Filenames: []string{"*.ik"},
+		MimeTypes: []string{"text/x-iokesrc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/irclogs.go
+++ b/lexers/i/irclogs.go
@@ -1,0 +1,19 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// IrcLogs lexer.
+var IrcLogs = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "IRC Logs",
+		Aliases:   []string{"irc"},
+		Filenames: []string{"*.weechatlog"},
+		MimeTypes: []string{"text/x-irclog"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/i/isabelle.go
+++ b/lexers/i/isabelle.go
@@ -1,0 +1,19 @@
+package i
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Isabelle lexer.
+var Isabelle = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Isabelle",
+		Aliases:   []string{"isabelle"},
+		Filenames: []string{"*.thy"},
+		MimeTypes: []string{"text/x-isabelle"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `i` package lexers.

- Icon - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Funicon.py#L167)
- Inform 6 template - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fint_fiction.py#L732)
- Inform 7 - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fint_fiction.py#L528-L529)
- Ioke - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fjvm.py#L551)
- IRC Logs - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Ftextfmts.py#L24)
- Isabelle - [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Ftheorem.py#L161)

Closes https://github.com/wakatime/wakatime-cli/issues/208