### PR TITLE
U lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -321,7 +321,7 @@
 | Typographic Number Theory     |                                     |                    |                    |
 | ucode                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Unicon                        |                                     |                    |                    |
+| Unicon                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | UrbiScript                    |                                     |                    |                    |
 | USD                           |                                     |                    |                    |
 | Vala                          | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -323,7 +323,7 @@
 | UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Unicon                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | UrbiScript                    |                                     |                    |                    |
-| USD                           |                                     |                    |                    |
+| USD                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Vala                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VCLSnippets                   | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -320,9 +320,8 @@
 | Turtle                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Typographic Number Theory     |                                     |                    |                    |
 | ucode                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Unicon                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| UrbiScript                    |                                     |                    |                    |
+| UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | USD                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Vala                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | VBScript                      | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/u/unicon.go
+++ b/lexers/u/unicon.go
@@ -1,0 +1,19 @@
+package u
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Unicon lexer.
+var Unicon = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Unicon",
+		Aliases:   []string{"unicon"},
+		Filenames: []string{"*.icn"},
+		MimeTypes: []string{"text/unicon"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/u/usd.go
+++ b/lexers/u/usd.go
@@ -1,0 +1,18 @@
+package u
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// USD lexer.
+var USD = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "USD",
+		Aliases:   []string{"usd", "usda"},
+		Filenames: []string{"*.usd", "*.usda"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `u` package lexers.

- Unicon
- USD

`ucode` and `UrbiScript` lexer, which are mentioned in the original issue, were already implemented earlier.

Closes https://github.com/wakatime/wakatime-cli/issues/220