### PR TITLE
T lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -317,7 +317,7 @@
 | Todotxt                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TrafficScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Treetop                       |                                     |                    |                    |
+| Treetop                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Turtle                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Typographic Number Theory     |                                     |                    |                    |
 | ucode                         |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -319,7 +319,7 @@
 | Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Treetop                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Turtle                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Typographic Number Theory     |                                     |                    |                    |
+| Typographic Number Theory     | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ucode                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Unicon                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | UrbiScript                    |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -307,7 +307,7 @@
 | sqlite3con                    |                                     |                    |                    |
 | Scalate Server Page           |                                     |                    |                    |
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| TAP                           |                                     |                    |                    |
+| TAP                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Tcsh Session                  |                                     |                    |                    |
 | Tea                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -309,7 +309,7 @@
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TAP                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Tcsh Session                  |                                     |                    |                    |
+| Tcsh Session                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Tea                           |                                     |                    |                    |
 | Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Text only                     |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -310,7 +310,7 @@
 | TAP                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Tcsh Session                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Tea                           |                                     |                    |                    |
+| Tea                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Text only                     |                                     |                    |                    |
 | tiddler                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -306,7 +306,6 @@
 | Debian Sourcelist             |                                     |                    |                    |
 | sqlite3con                    |                                     |                    |                    |
 | Scalate Server Page           |                                     |                    |                    |
-| TrafficScript                 |                                     |                    |                    |
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TAP                           |                                     |                    |                    |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
@@ -316,6 +315,7 @@
 | Text only                     |                                     |                    |                    |
 | tiddler                       |                                     |                    |                    |
 | Todotxt                       |                                     |                    |                    |
+| TrafficScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Treetop                       |                                     |                    |                    |
 | Turtle                        |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -314,7 +314,7 @@
 | Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Text only                     |                                     |                    |                    |
 | tiddler                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Todotxt                       |                                     |                    |                    |
+| Todotxt                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TrafficScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Treetop                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -313,7 +313,7 @@
 | Tea                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Text only                     |                                     |                    |                    |
-| tiddler                       |                                     |                    |                    |
+| tiddler                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Todotxt                       |                                     |                    |                    |
 | TrafficScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Transact-SQL                  |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -312,7 +312,8 @@
 | Tcsh Session                  | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Tea                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Tera Term macro               |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Text only                     |                                     |                    |                    |
+| Text only                     | Named "plaintext" lexer in chroma   | :heavy_check_mark: |                    |
+|                               | No text analysis exists in pygments |                    |                    |
 | tiddler                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Todotxt                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TrafficScript                 | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/t/tap.go
+++ b/lexers/t/tap.go
@@ -1,0 +1,18 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// TAP lexer. For Test Anything Protocol (TAP) output.
+var TAP = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "TAP",
+		Aliases:   []string{"tap"},
+		Filenames: []string{"*.tap"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/tcshsession.go
+++ b/lexers/t/tcshsession.go
@@ -1,0 +1,18 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// TcshSession lexer. Lexer for Tcsh sessions, i.e. command lines, including a
+// prompt, interspersed with output.
+var TcshSession = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "Tcsh Session",
+		Aliases: []string{"tcshcon"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/tea.go
+++ b/lexers/t/tea.go
@@ -1,0 +1,19 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Tea lexer. Lexer for Tea Templates <http://teatrove.org/>.
+var Tea = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Tea",
+		Aliases:   []string{"tea"},
+		Filenames: []string{"*.tea"},
+		MimeTypes: []string{"text/x-tea"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/tiddler.go
+++ b/lexers/t/tiddler.go
@@ -1,0 +1,19 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Tiddler lexer. For TiddlyWiki5 <https://tiddlywiki.com/#TiddlerFiles> markup.
+var Tiddler = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "tiddler",
+		Aliases:   []string{"tid"},
+		Filenames: []string{"*.tid"},
+		MimeTypes: []string{"text/vnd.tiddlywiki"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/tnt.go
+++ b/lexers/t/tnt.go
@@ -1,0 +1,20 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// TNT lexer. Lexer for Typographic Number Theory, as described in the book
+// Gödel, Escher, Bach, by Douglas R. Hofstadter, or as summarized here:
+// https://github.com/Kenny2github/language-tnt/blob/master/README.md#summary-of-tnt
+var TNT = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Typographic Number Theory",
+		Aliases:   []string{"tnt"},
+		Filenames: []string{"*.tnt"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/todotxt.go
+++ b/lexers/t/todotxt.go
@@ -1,0 +1,21 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Todotxt lexer. Lexer for Todo.txt <http://todotxt.com/> todo list format.
+var Todotxt = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "Todotxt",
+		Aliases: []string{"todotxt"},
+		// *.todotxt is not a standard extension for Todo.txt files; including it
+		// makes testing easier, and also makes autodetecting file type easier.
+		Filenames: []string{"todo.txt", "*.todotxt"},
+		MimeTypes: []string{"text/x-todo"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/trafficscript.go
+++ b/lexers/t/trafficscript.go
@@ -1,0 +1,19 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// TrafficScript lexer. For `Riverbed Stingray Traffic Manager
+// <http://www.riverbed.com/stingray>`
+var TrafficScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "TrafficScript",
+		Aliases:   []string{"rts", "trafficscript"},
+		Filenames: []string{"*.rts"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/t/treetop.go
+++ b/lexers/t/treetop.go
@@ -1,0 +1,18 @@
+package t
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Treetop lexer. A lexer for Treetop <http://treetop.rubyforge.org/> grammars.
+var Treetop = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Treetop",
+		Aliases:   []string{"treetop"},
+		Filenames: []string{"*.treetop", "*.tt"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
Port missing `t` lexers to Chroma.

- TrafficScript
- TAP
- Tcsh Session
- Tea
- tiddler
- Todotxt
- Treetop
- Typographic Number Theory

`Text only` lexer is already implemented as `plaintext` in chroma. `TADS 3`, `TASM`, `Tera Term macro`, `Transact-SQL` and `Turtle`, which were mentioned in the original issue are already implemented.

Closes https://github.com/wakatime/wakatime-cli/issues/219
