### PR TITLE
K lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -191,7 +191,7 @@
 | Julia console                 |                                     |                    |                    |
 | Juttle                        |                                     |                    |                    |
 | Kal                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Kconfig                       |                                     |                    |                    |
+| Kconfig                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kernel log                    |                                     |                    |                    |
 | Koka                          |                                     |                    |                    |
 | LSL                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -192,7 +192,7 @@
 | Juttle                        |                                     |                    |                    |
 | Kal                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kconfig                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Kernel log                    |                                     |                    |                    |
+| Kernel log                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Koka                          |                                     |                    |                    |
 | LSL                           |                                     |                    |                    |
 | Lean                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -193,7 +193,7 @@
 | Kal                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kconfig                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kernel log                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Koka                          |                                     |                    |                    |
+| Koka                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LSL                           |                                     |                    |                    |
 | Lean                          |                                     |                    |                    |
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -190,7 +190,7 @@
 | Java Server Page              |                                     |                    |                    |
 | Julia console                 |                                     |                    |                    |
 | Juttle                        |                                     |                    |                    |
-| Kal                           |                                     |                    |                    |
+| Kal                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kconfig                       |                                     |                    |                    |
 | Kernel log                    |                                     |                    |                    |
 | Koka                          |                                     |                    |                    |

--- a/lexers/k/kal.go
+++ b/lexers/k/kal.go
@@ -1,0 +1,19 @@
+package k
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Kal lexer.
+var Kal = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Kal",
+		Aliases:   []string{"kal"},
+		Filenames: []string{"*.kal"},
+		MimeTypes: []string{"text/kal", "application/kal"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/k/kconfig.go
+++ b/lexers/k/kconfig.go
@@ -1,0 +1,20 @@
+package k
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Kconfig lexer.
+var Kconfig = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "Kconfig",
+		Aliases: []string{"kconfig", "menuconfig", "linux-config", "kernel-config"},
+		// Adjust this if new kconfig file names appear in your environment.
+		Filenames: []string{"Kconfig*", "*Config.in*", "external.in*", "standard-modules.in"},
+		MimeTypes: []string{"text/x-kconfig"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/k/kernellog.go
+++ b/lexers/k/kernellog.go
@@ -1,0 +1,18 @@
+package k
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// KernelLog lexer.
+var KernelLog = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Kernel log",
+		Aliases:   []string{"kmsg", "dmesg"},
+		Filenames: []string{"*.kmsg", "*.dmesg"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/k/koka.go
+++ b/lexers/k/koka.go
@@ -1,0 +1,19 @@
+package k
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Koka lexer.
+var Koka = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Koka",
+		Aliases:   []string{"koka"},
+		Filenames: []string{"*.kk", "*.kki"},
+		MimeTypes: []string{"text/x-koka"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds missing `k` package lexers.

- Kal [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fjavascript.py#L117)
- Kconfig [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fconfigs.py#L149)
- Kernel log [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Ftextfmts.py#L384)
- Koka [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L657)

Closes https://github.com/wakatime/wakatime-cli/issues/210