### PR TITLE
L lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -205,7 +205,7 @@
 | LiveScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Logos                         |                                     | :heavy_check_mark: |                    |
+| Logos                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Logtalk                       |                                     |                    |                    |
 | MIME                          |                                     |                    |                    |
 | MOOCode                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -199,7 +199,7 @@
 | Lean                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Literate Agda                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Literate Cryptol              |                                     |                    |                    |
+| Literate Cryptol              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Haskell              |                                     |                    |                    |
 | Literate Idris                |                                     |                    |                    |
 | LiveScript                    |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -198,7 +198,7 @@
 | LSL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Lean                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Literate Agda                 |                                     |                    |                    |
+| Literate Agda                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Cryptol              |                                     |                    |                    |
 | Literate Haskell              |                                     |                    |                    |
 | Literate Idris                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -206,7 +206,7 @@
 | LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Logos                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Logtalk                       |                                     | :heavy_check_mark: |                    |
+| Logtalk                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | MIME                          |                                     |                    |                    |
 | MOOCode                       |                                     |                    |                    |
 | MSDOS Session                 |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -206,7 +206,7 @@
 | LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Logos                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Logtalk                       |                                     |                    |                    |
+| Logtalk                       |                                     | :heavy_check_mark: |                    |
 | MIME                          |                                     |                    |                    |
 | MOOCode                       |                                     |                    |                    |
 | MSDOS Session                 |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -203,8 +203,8 @@
 | Literate Haskell              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Idris                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LiveScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 |                                     |                    |                    |
-| LLVM-MIR                      |                                     |                    |                    |
 | Logos                         |                                     |                    |                    |
 | Logtalk                       |                                     |                    |                    |
 | MIME                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -196,7 +196,7 @@
 | Kernel log                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Koka                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LSL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Lean                          |                                     |                    |                    |
+| Lean                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Literate Agda                 |                                     |                    |                    |
 | Literate Cryptol              |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -201,7 +201,7 @@
 | Literate Agda                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Cryptol              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Haskell              | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Literate Idris                |                                     |                    |                    |
+| Literate Idris                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LiveScript                    |                                     |                    |                    |
 | LLVM-MIR Body                 |                                     |                    |                    |
 | LLVM-MIR                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -202,7 +202,7 @@
 | Literate Cryptol              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Haskell              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Idris                | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| LiveScript                    |                                     |                    |                    |
+| LiveScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 |                                     |                    |                    |
 | LLVM-MIR                      |                                     |                    |                    |
 | Logos                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -200,7 +200,7 @@
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Literate Agda                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Cryptol              | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Literate Haskell              |                                     |                    |                    |
+| Literate Haskell              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Literate Idris                |                                     |                    |                    |
 | LiveScript                    |                                     |                    |                    |
 | LLVM-MIR Body                 |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -205,7 +205,7 @@
 | LiveScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR Body                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Logos                         |                                     |                    |                    |
+| Logos                         |                                     | :heavy_check_mark: |                    |
 | Logtalk                       |                                     |                    |                    |
 | MIME                          |                                     |                    |                    |
 | MOOCode                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -204,7 +204,7 @@
 | Literate Idris                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LiveScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | LLVM-MIR                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| LLVM-MIR Body                 |                                     |                    |                    |
+| LLVM-MIR Body                 | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Logos                         |                                     |                    |                    |
 | Logtalk                       |                                     |                    |                    |
 | MIME                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -195,7 +195,7 @@
 | Kconfig                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Kernel log                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Koka                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| LSL                           |                                     |                    |                    |
+| LSL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Lean                          |                                     |                    |                    |
 | Limbo                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Literate Agda                 |                                     |                    |                    |

--- a/lexers/l/lean.go
+++ b/lexers/l/lean.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Lean lexer.
+var Lean = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Lean",
+		Aliases:   []string{"lean"},
+		Filenames: []string{"*.lean"},
+		MimeTypes: []string{"text/x-lean"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/literateagda.go
+++ b/lexers/l/literateagda.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LiterateAgda lexer.
+var LiterateAgda = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Literate Agda",
+		Aliases:   []string{"lagda", "literate-agda"},
+		Filenames: []string{"*.lagda"},
+		MimeTypes: []string{"text/x-literate-agda"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/literatecryptol.go
+++ b/lexers/l/literatecryptol.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LiterateCryptol lexer.
+var LiterateCryptol = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Literate Cryptol",
+		Aliases:   []string{"lcry", "literate-cryptol", "lcryptol"},
+		Filenames: []string{"*.lcry"},
+		MimeTypes: []string{"text/x-literate-cryptol"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/literatehaskell.go
+++ b/lexers/l/literatehaskell.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LiterateHaskell lexer.
+var LiterateHaskell = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Literate Haskell",
+		Aliases:   []string{"lhs", "literate-haskell", "lhaskell"},
+		Filenames: []string{"*.lhs"},
+		MimeTypes: []string{"text/x-literate-haskell"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/literateidris.go
+++ b/lexers/l/literateidris.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LiterateIdris lexer.
+var LiterateIdris = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Literate Idris",
+		Aliases:   []string{"lidr", "literate-idris", "lidris"},
+		Filenames: []string{"*.lidr"},
+		MimeTypes: []string{"text/x-literate-idris"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/livescript.go
+++ b/lexers/l/livescript.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LiveScript lexer.
+var LiveScript = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "LiveScript",
+		Aliases:   []string{"live-script", "livescript"},
+		Filenames: []string{"*.ls"},
+		MimeTypes: []string{"text/livescript"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/llvmmir.go
+++ b/lexers/l/llvmmir.go
@@ -1,0 +1,18 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LlvmMir lexer.
+var LlvmMir = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "LLVM-MIR",
+		Aliases:   []string{"llvm-mir"},
+		Filenames: []string{"*.mir"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/llvmmirbody.go
+++ b/lexers/l/llvmmirbody.go
@@ -1,0 +1,17 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LlvmMirBody lexer.
+var LlvmMirBody = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "LLVM-MIR Body",
+		Aliases: []string{"llvm-mir-body"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/logos.go
+++ b/lexers/l/logos.go
@@ -1,9 +1,13 @@
 package l
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var logosAnalyserKeywordsRe = regexp.MustCompile(`%(?:hook|ctor|init|c\()`)
 
 // Logos lexer.
 var Logos = internal.Register(MustNewLexer(
@@ -17,4 +21,10 @@ var Logos = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if logosAnalyserKeywordsRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/l/logos.go
+++ b/lexers/l/logos.go
@@ -1,0 +1,20 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Logos lexer.
+var Logos = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Logos",
+		Aliases:   []string{"logos"},
+		Filenames: []string{"*.x", "*.xi", "*.xm", "*.xmi"},
+		MimeTypes: []string{"text/x-logos"},
+		Priority:  0.25,
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/logos_test.go
+++ b/lexers/l/logos_test.go
@@ -1,0 +1,20 @@
+package l_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/l"
+)
+
+func TestLogos_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/logos_basic.xm")
+	assert.NoError(t, err)
+
+	analyser, ok := l.Logos.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/l/logtalk.go
+++ b/lexers/l/logtalk.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Logtalk lexer.
+var Logtalk = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Logtalk",
+		Aliases:   []string{"logtalk"},
+		Filenames: []string{"*.lgt", "*.logtalk"},
+		MimeTypes: []string{"text/x-logtalk"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/logtalk.go
+++ b/lexers/l/logtalk.go
@@ -1,9 +1,14 @@
 package l
 
 import (
+	"regexp"
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
+
+var logtalkAnalyserSyntaxRe = regexp.MustCompile(`(?m)^:-\s[a-z]`)
 
 // Logtalk lexer.
 var Logtalk = internal.Register(MustNewLexer(
@@ -16,4 +21,16 @@ var Logtalk = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, ":- object(") ||
+		strings.Contains(text, ":- protocol(") ||
+		strings.Contains(text, ":- category(") {
+		return 1.0
+	}
+
+	if logtalkAnalyserSyntaxRe.MatchString(text) {
+		return 0.9
+	}
+
+	return 0
+}))

--- a/lexers/l/logtalk_test.go
+++ b/lexers/l/logtalk_test.go
@@ -1,0 +1,39 @@
+package l_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/l"
+)
+
+func TestLogtalk_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"object": {
+			Filepath: "testdata/logtalk_object.lgt",
+			Expected: 1.0,
+		},
+		"basic": {
+			Filepath: "testdata/logtalk_basic.lgt",
+			Expected: 0.9,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := l.Logtalk.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/l/lsl.go
+++ b/lexers/l/lsl.go
@@ -1,0 +1,19 @@
+package l
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// LSL lexer.
+var LSL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "LSL",
+		Aliases:   []string{"lsl"},
+		Filenames: []string{"*.lsl"},
+		MimeTypes: []string{"text/x-lsl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/l/testdata/logos_basic.xm
+++ b/lexers/l/testdata/logos_basic.xm
@@ -1,0 +1,28 @@
+%hook ABC
+- (id)a:(B)b {
+	%log;
+	return %orig(nil);
+}
+%end
+
+%subclass DEF: NSObject
+- (id)init {
+	[%c(RuntimeAccessibleClass) alloc];
+	return nil;
+}
+%end
+
+%group OptionalHooks
+%hook ABC
+- (void)release {
+	[self retain];
+	%orig;
+}
+%end
+%end
+
+%ctor {
+	%init;
+	if(OptionalCondition)
+		%init(OptionalHooks);
+}

--- a/lexers/l/testdata/logtalk_basic.lgt
+++ b/lexers/l/testdata/logtalk_basic.lgt
@@ -1,0 +1,2 @@
+:- public(p1/0).
+p1 :- write('This is a public predicate'), nl.

--- a/lexers/l/testdata/logtalk_object.lgt
+++ b/lexers/l/testdata/logtalk_object.lgt
@@ -1,0 +1,1 @@
+:- object(my_first_object).


### PR DESCRIPTION
This PR adds missing `l` package lexers.

- LSL [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fscripting.py#L299)
- Lean [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Ftheorem.py#L377)
- Literate Agda [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L611)
- Literate Cryptol [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L634)
- Literal Haskell [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L565)
- Literate Idris [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fhaskell.py#L588)
- Live Script [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fjavascript.py#L232)
- LLVM-MIR [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fasm.py#L599)
- LLVM-MIR Body [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fasm.py#L458)
- Logos [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fobjective.py#L219)
- Logtalk [ref](https://github.com/pygments/pygments/blob/a590ac5ea7c00a41e253834306bfa19e38349c0b/pygments%2Flexers%2Fprolog.py#L87)

Closes https://github.com/wakatime/wakatime-cli/issues/211