### PR TITLE
S lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -296,7 +296,7 @@
 | Silver                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Slash                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Slurm                         | No text analysis exists in pygments |                    |                    |
+| Slurm                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SmartGameFormat               |                                     |                    |                    |
 | Snowball                      |                                     |                    |                    |
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -301,7 +301,7 @@
 | Snowball                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Stan                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Stata                         |                                     |                    |                    |
+| Stata                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Debian Sourcelist             |                                     |                    |                    |
 | sqlite3con                    |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -288,7 +288,7 @@
 | Ruby irb session              |                                     |                    |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
 | SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Scaml                         |                                     |                    |                    |
+| Scaml                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | ShExC                         |                                     |                    |                    |
 | Shen                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -287,7 +287,7 @@
 | RSL                           |                                     |                    |                    |
 | Ruby irb session              |                                     |                    |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
-| SARL                          |                                     |                    |                    |
+| SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Scaml                         |                                     |                    |                    |
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | ShExC                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -303,7 +303,7 @@
 | Stan                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Stata                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Debian Sourcelist             |                                     |                    |                    |
+| Sourcelist/Debian Sourceslist |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | sqlite3con                    |                                     |                    |                    |
 | Scalate Server Page           |                                     |                    |                    |
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -298,7 +298,7 @@
 | Slash                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Slurm                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SmartGameFormat               | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Snowball                      |                                     |                    |                    |
+| Snowball                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Stan                          |                                     |                    |                    |
 | Stata                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -300,7 +300,7 @@
 | SmartGameFormat               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Snowball                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Stan                          |                                     |                    |                    |
+| Stan                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Stata                         |                                     |                    |                    |
 | SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Debian Sourcelist             |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -295,7 +295,7 @@
 | Sieve                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Silver                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Slash                         | No text analysis exists in pygments |                    |                    |
+| Slash                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Slurm                         | No text analysis exists in pygments |                    |                    |
 | SmartGameFormat               |                                     |                    |                    |
 | Snowball                      |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -292,7 +292,7 @@
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Shen                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ShExC                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Sieve                         |                                     |                    |                    |
+| Sieve                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Silver                        |                                     |                    |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Slash                         | No text analysis exists in pygments |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -297,7 +297,7 @@
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Slash                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Slurm                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| SmartGameFormat               |                                     |                    |                    |
+| SmartGameFormat               | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Snowball                      |                                     |                    |                    |
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Stan                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -290,8 +290,8 @@
 | SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Scaml                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
+| Shen                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ShExC                         |                                     |                    |                    |
-| Shen                          |                                     |                    |                    |
 | Sieve                         |                                     |                    |                    |
 | Silver                        |                                     |                    |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -288,6 +288,7 @@
 | Ruby irb session              |                                     |                    |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
 | SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
+| Scalate Server Page           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Scaml                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Shen                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
@@ -305,7 +306,6 @@
 | SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Sourcelist/Debian Sourceslist |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | sqlite3con                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Scalate Server Page           |                                     |                    |                    |
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TAP                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -304,7 +304,7 @@
 | Stata                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | SuperCollider                 |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Sourcelist/Debian Sourceslist |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| sqlite3con                    |                                     |                    |                    |
+| sqlite3con                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Scalate Server Page           |                                     |                    |                    |
 | TADS 3                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TAP                           | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -293,7 +293,7 @@
 | Shen                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ShExC                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Sieve                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Silver                        |                                     |                    |                    |
+| Silver                        | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Slash                         | No text analysis exists in pygments |                    |                    |
 | Slurm                         | No text analysis exists in pygments |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -291,7 +291,7 @@
 | Scaml                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | scdoc                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Shen                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| ShExC                         |                                     |                    |                    |
+| ShExC                         | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Sieve                         |                                     |                    |                    |
 | Silver                        |                                     |                    |                    |
 | Singularity                   |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/s/sarl.go
+++ b/lexers/s/sarl.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SARL lexer. For SARL <http://www.sarl.io> source code.
+var SARL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SARL",
+		Aliases:   []string{"sarl"},
+		Filenames: []string{"*.sarl"},
+		MimeTypes: []string{"text/x-sarl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/scaml.go
+++ b/lexers/s/scaml.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Scaml lexer. For Scaml markup <http://scalate.fusesource.org/>. Scaml is Haml for Scala.
+var Scaml = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Scaml",
+		Aliases:   []string{"scaml"},
+		Filenames: []string{"*.scaml"},
+		MimeTypes: []string{"text/x-scaml"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sgf.go
+++ b/lexers/s/sgf.go
@@ -1,0 +1,22 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// SmartGameFormat lexer. Lexer for Smart Game Format (sgf) file format.
+//
+// The format is used to store game records of board games for two players
+// (mainly Go game). For more information about the definition of the format,
+// see: https://www.red-bean.com/sgf/
+var SmartGameFormat = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "SmartGameFormat",
+		Aliases:   []string{"sgf"},
+		Filenames: []string{"*.sgf"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/shen.go
+++ b/lexers/s/shen.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Shen lexer. Lexer for Shen <http://shenlanguage.org/> source code.
+var Shen = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Shen",
+		Aliases:   []string{"shen"},
+		Filenames: []string{"*.shen"},
+		MimeTypes: []string{"text/x-shen", "application/x-shen"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/shexc.go
+++ b/lexers/s/shexc.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// ShExC lexer. Lexer for ShExC <https://shex.io/shex-semantics/#shexc> shape expressions language syntax.
+var ShExC = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "ShExC",
+		Aliases:   []string{"shexc", "shex"},
+		Filenames: []string{"*.shex"},
+		MimeTypes: []string{"text/shex"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sieve.go
+++ b/lexers/s/sieve.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Sieve lexer. Lexer for sieve format.
+var Sieve = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Sieve",
+		Aliases:   []string{"sieve"},
+		Filenames: []string{"*.siv", "*.sieve"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/silver.go
+++ b/lexers/s/silver.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Silver lexer. For Silver <https://bitbucket.org/viperproject/silver> source code.
+var Silver = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Silver",
+		Aliases:   []string{"silver"},
+		Filenames: []string{"*.sil", "*.vpr"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/slash.go
+++ b/lexers/s/slash.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Slash lexer. Lexer for the Slash programming language.
+var Slash = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Slash",
+		Aliases:   []string{"slash"},
+		Filenames: []string{"*.sla"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/slurm.go
+++ b/lexers/s/slurm.go
@@ -1,0 +1,26 @@
+package s
+
+import (
+	"github.com/alecthomas/chroma"
+	. "github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/b"
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Slurm lexer. Lexer for (ba|k|z|)sh Slurm scripts.
+var Slurm = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Slurm",
+		Aliases:   []string{"slurm", "sbatch"},
+		Filenames: []string{"*.sl"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	if analyser, ok := b.Bash.(chroma.Analyser); ok {
+		return analyser.AnalyseText(text)
+	}
+
+	return 0
+}))

--- a/lexers/s/slurm_test.go
+++ b/lexers/s/slurm_test.go
@@ -1,0 +1,20 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestSlurm_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/slurm.sl")
+	assert.NoError(t, err)
+
+	analyser, ok := s.Slurm.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/s/snowball.go
+++ b/lexers/s/snowball.go
@@ -1,0 +1,18 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Snowball lexer. Lexer for Snowball <http://snowballstem.org/> source code.
+var Snowball = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Snowball",
+		Aliases:   []string{"snowball"},
+		Filenames: []string{"*.sbl"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/sourceslist.go
+++ b/lexers/s/sourceslist.go
@@ -1,0 +1,29 @@
+package s
+
+import (
+	"regexp"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var sourcesListAnalyserRe = regexp.MustCompile(`(?m)^\s*(deb|deb-src) `)
+
+// SourcesList lexer. Lexer that highlights debian sources.list files.
+var SourcesList = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Debian Sourcelist",
+		Aliases:   []string{"sourceslist", "sources.list", "debsources"},
+		Filenames: []string{"sources.list"},
+		MimeTypes: []string{"application/x-debian-sourceslist"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	if sourcesListAnalyserRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/s/sourceslist_test.go
+++ b/lexers/s/sourceslist_test.go
@@ -1,0 +1,43 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestSourcesList_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"standard": {
+			Filepath: "testdata/sources.list",
+			Expected: 1.0,
+		},
+		"indented": {
+			Filepath: "testdata/sources-indented.list",
+			Expected: 1.0,
+		},
+		"invalid": {
+			Filepath: "testdata/sources-invalid.list",
+			Expected: 0.0,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := s.SourcesList.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/s/sqlite3con.go
+++ b/lexers/s/sqlite3con.go
@@ -1,0 +1,19 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Sqlite3con lexer. Lexer for example sessions using sqlite3.
+var Sqlite3con = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "sqlite3con",
+		Aliases:   []string{"sqlite3"},
+		Filenames: []string{"*.sqlite3-console"},
+		MimeTypes: []string{"text/x-sqlite3-console"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/ssp.go
+++ b/lexers/s/ssp.go
@@ -1,0 +1,41 @@
+package s
+
+import (
+	"regexp"
+	"strings"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/xml"
+)
+
+var sspAnalyserRe = regexp.MustCompile(`val \w+\s*:`)
+
+// SSP lexer. Lexer for Scalate Server Pages.
+var SSP = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Scalate Server Page",
+		Aliases:   []string{"ssp"},
+		Filenames: []string{"*.ssp"},
+		MimeTypes: []string{"application/x-ssp"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	var result float64
+
+	if sspAnalyserRe.MatchString(text) {
+		result += 0.6
+	}
+
+	if xml.MatchString(text) {
+		result += 0.2
+	}
+
+	if strings.Contains(text, "<%") && strings.Contains(text, "%>") {
+		result += 0.1
+	}
+
+	return float32(result)
+}))

--- a/lexers/s/ssp_test.go
+++ b/lexers/s/ssp_test.go
@@ -1,0 +1,20 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestSSP_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/ssp_basic.ssp")
+	assert.NoError(t, err)
+
+	analyser, ok := s.SSP.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(0.9), analyser.AnalyseText(string(data)))
+}

--- a/lexers/s/stan.go
+++ b/lexers/s/stan.go
@@ -1,0 +1,32 @@
+package s
+
+import (
+	"regexp"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var stanAnalyserRe = regexp.MustCompile(`(?m)^\s*parameters\s*\{`)
+
+// Stan lexer. Lexer for Stan models.
+//
+// The Stan modeling language is specified in the *Stan Modeling Language
+// User's Guide and Reference Manual, v2.17.0*,
+// pdf <https://github.com/stan-dev/stan/releases/download/v2.17.0/stan-reference-2.17.0.pdf>`.
+var Stan = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Stan",
+		Aliases:   []string{"stan"},
+		Filenames: []string{"*.stan"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	if stanAnalyserRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/s/stan_test.go
+++ b/lexers/s/stan_test.go
@@ -1,0 +1,20 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestStan_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/stan_basic.stan")
+	assert.NoError(t, err)
+
+	analyser, ok := s.Stan.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/s/stata.go
+++ b/lexers/s/stata.go
@@ -1,0 +1,24 @@
+package s
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Stata lexer. For Stata <http://www.stata.com/> do files.
+//
+// Syntax based on
+// - http://fmwww.bc.edu/RePEc/bocode/s/synlightlist.ado
+// - https://github.com/isagalaev/highlight.js/blob/master/src/languages/stata.js
+// - https://github.com/jpitblado/vim-stata/blob/master/syntax/stata.vim
+var Stata = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Stata",
+		Aliases:   []string{"stata", "do"},
+		Filenames: []string{"*.do", "*.ado"},
+		MimeTypes: []string{"text/x-stata", "text/stata", "application/x-stata"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/s/testdata/slurm.sl
+++ b/lexers/s/testdata/slurm.sl
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=serial_job_test    # Job name
+#SBATCH --mail-type=END,FAIL          # Mail events (NONE, BEGIN, END, FAIL, ALL)
+#SBATCH --mail-user=email@ufl.edu     # Where to send mail	
+#SBATCH --ntasks=1                    # Run on a single CPU
+#SBATCH --mem=1gb                     # Job memory request
+#SBATCH --time=00:05:00               # Time limit hrs:min:sec
+#SBATCH --output=serial_test_%j.log   # Standard output and error log
+pwd; hostname; date
+
+module load python
+
+echo "Running plot script on a single CPU core"
+
+python /ufrc/data/training/SLURM/plot_template.py
+
+date

--- a/lexers/s/testdata/sources-indented.list
+++ b/lexers/s/testdata/sources-indented.list
@@ -1,0 +1,3 @@
+
+  deb http://deb.debian.org/debian buster main
+  deb-src http://deb.debian.org/debian buster main

--- a/lexers/s/testdata/sources-invalid.list
+++ b/lexers/s/testdata/sources-invalid.list
@@ -1,0 +1,3 @@
+
+  xxx deb http://deb.debian.org/debian buster main
+  xxx deb-src http://deb.debian.org/debian buster main

--- a/lexers/s/testdata/sources.list
+++ b/lexers/s/testdata/sources.list
@@ -1,0 +1,8 @@
+deb http://deb.debian.org/debian buster main
+deb-src http://deb.debian.org/debian buster main
+
+deb http://deb.debian.org/debian-security/ buster/updates main
+deb-src http://deb.debian.org/debian-security/ buster/updates main
+
+deb http://deb.debian.org/debian buster-updates main
+deb-src http://deb.debian.org/debian buster-updates main

--- a/lexers/s/testdata/ssp_basic.ssp
+++ b/lexers/s/testdata/ssp_basic.ssp
@@ -1,0 +1,2 @@
+<%@ import val model: Person %>
+<p>Hello ${name}, what is the weather like in ${city}</p>

--- a/lexers/s/testdata/stan_basic.stan
+++ b/lexers/s/testdata/stan_basic.stan
@@ -1,0 +1,18 @@
+data {
+  int<lower=0> n; //number of schools
+  real y[n]; // effect of coaching
+  real<lower=0> sigma[n]; // standard errors of effects
+}
+parameters {
+  real mu;  // the overall mean effect
+  real<lower=0> tau; // the inverse variance of the effect
+  vector[n] eta; // standardized school-level effects (see below)
+}
+transformed parameters {
+  vector[n] theta; 
+  theta = mu + tau * eta; // find theta from mu, tau, and eta
+}
+model {
+  target += normal_lpdf(eta | 0, 1); // eta follows standard normal
+  target += normal_lpdf(y | theta, sigma);  // y follows normal with mean theta and sd sigma
+}


### PR DESCRIPTION
Port missing `s` lexers to Chroma.

- SARL
- Scaml
- ShExC
- Shen
- Sieve
- Silver
- Slash
- Slurm
- SmartGameFormat
- Snowball
- Sourcelist/Debian Sourceslist
- sqlite3con
- SSP

Lexers `scdoc`, `S`, `Singularity`, `SQL`, `SuperCollider`, which were mentioned in the original issue are already implemented.

Closes wakatime/wakatime-cli#218