### PR TITLE
R lexers

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -279,7 +279,7 @@
 | QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | QVTO                          |                                     |                    |                    |
 | RConsole                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Relax-NG Compact              |                                     |                    |                    |
+| Relax-NG Compact              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Embedded Ragel                |                                     |                    |                    |
 | Raw token data                |                                     |                    |                    |
 | Rd                            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -289,7 +289,7 @@
 | ResourceBundle                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | RHTML                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Ride                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Roboconf Graph                |                                     |                    |                    |
+| Roboconf Graph                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Instances            |                                     |                    |                    |
 | RobotFramework                |                                     |                    |                    |
 | RQL                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -287,7 +287,7 @@
 | Red                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Redcode                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ResourceBundle                |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| RHTML                         |                                     |                    |                    |
+| RHTML                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Ride                          |                                     |                    |                    |
 | Roboconf Graph                |                                     |                    |                    |
 | Roboconf Instances            |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -286,7 +286,7 @@
 | REBOL                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Red                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Redcode                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| ResourceBundle                |                                     |                    |                    |
+| ResourceBundle                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | RHTML                         |                                     |                    |                    |
 | Ride                          |                                     |                    |                    |
 | Roboconf Graph                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -293,7 +293,7 @@
 | Roboconf Instances            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RobotFramework                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RQL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| RSL                           |                                     |                    |                    |
+| RSL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Ruby irb session              |                                     |                    |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
 | SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -280,7 +280,7 @@
 | QVTO                          |                                     |                    |                    |
 | RConsole                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Relax-NG Compact              | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Embedded Ragel                |                                     |                    |                    |
+| Ragel Embedded                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Raw token data                |                                     |                    |                    |
 | Rd                            |                                     |                    |                    |
 | REBOL                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -291,7 +291,7 @@
 | Ride                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Graph                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Instances            | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| RobotFramework                |                                     |                    |                    |
+| RobotFramework                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RQL                           |                                     |                    |                    |
 | RSL                           |                                     |                    |                    |
 | Ruby irb session              |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -288,7 +288,7 @@
 | Redcode                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ResourceBundle                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | RHTML                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Ride                          |                                     |                    |                    |
+| Ride                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Graph                |                                     |                    |                    |
 | Roboconf Instances            |                                     |                    |                    |
 | RobotFramework                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -284,7 +284,7 @@
 | Raw token data                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Rd                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | REBOL                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Red                           |                                     |                    |                    |
+| Red                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Redcode                       |                                     |                    |                    |
 | ResourceBundle                |                                     |                    |                    |
 | RHTML                         |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -285,7 +285,7 @@
 | Rd                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | REBOL                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Red                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Redcode                       |                                     |                    |                    |
+| Redcode                       | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | ResourceBundle                |                                     |                    |                    |
 | RHTML                         |                                     |                    |                    |
 | Ride                          |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -283,7 +283,7 @@
 | Ragel Embedded                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Raw token data                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Rd                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| REBOL                         |                                     |                    |                    |
+| REBOL                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Red                           |                                     |                    |                    |
 | Redcode                       |                                     |                    |                    |
 | ResourceBundle                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -294,7 +294,7 @@
 | RobotFramework                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RQL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RSL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Ruby irb session              |                                     |                    |                    |
+| Ruby irb session              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |
 | SARL                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Scalate Server Page           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -278,7 +278,7 @@
 | Python Traceback              |                                     |                    |                    |
 | QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | QVTO                          |                                     |                    |                    |
-| RConsole                      |                                     |                    |                    |
+| RConsole                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Relax-NG Compact              |                                     |                    |                    |
 | Embedded Ragel                |                                     |                    |                    |
 | Raw token data                |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -282,7 +282,7 @@
 | Relax-NG Compact              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Ragel Embedded                |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Raw token data                | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Rd                            |                                     |                    |                    |
+| Rd                            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | REBOL                         |                                     |                    |                    |
 | Red                           |                                     |                    |                    |
 | Redcode                       |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -290,7 +290,7 @@
 | RHTML                         |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Ride                          | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Graph                | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| Roboconf Instances            |                                     |                    |                    |
+| Roboconf Instances            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RobotFramework                |                                     |                    |                    |
 | RQL                           |                                     |                    |                    |
 | RSL                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -281,7 +281,7 @@
 | RConsole                      | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Relax-NG Compact              | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Ragel Embedded                |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Raw token data                |                                     |                    |                    |
+| Raw token data                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Rd                            |                                     |                    |                    |
 | REBOL                         |                                     |                    |                    |
 | Red                           |                                     |                    |                    |

--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -292,7 +292,7 @@
 | Roboconf Graph                | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | Roboconf Instances            | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RobotFramework                | No text analysis exists in pygments | :heavy_check_mark: |                    |
-| RQL                           |                                     |                    |                    |
+| RQL                           | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | RSL                           |                                     |                    |                    |
 | Ruby irb session              |                                     |                    |                    |
 | S                             | It's implemented altogether in r.go | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/r/ragelembedded.go
+++ b/lexers/r/ragelembedded.go
@@ -1,0 +1,26 @@
+package r
+
+import (
+	"strings"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RagelEmbedded lexer. A lexer for Ragel embedded in a host language file.
+var RagelEmbedded = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Embedded Ragel",
+		Aliases:   []string{"ragel-em"},
+		Filenames: []string{"*.rl"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	if strings.Contains(text, "@LANG: indep") {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/r/ragelembedded_test.go
+++ b/lexers/r/ragelembedded_test.go
@@ -1,0 +1,20 @@
+package r_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
+)
+
+func TestRagelEmbedded_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/ragel.rl")
+	assert.NoError(t, err)
+
+	analyser, ok := r.RagelEmbedded.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/r/rawtoken.go
+++ b/lexers/r/rawtoken.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RawToken lexer.
+var RawToken = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Raw token data",
+		Aliases:   []string{"raw"},
+		MimeTypes: []string{"application/x-pygments-tokens"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rconsole.go
+++ b/lexers/r/rconsole.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RConsole lexer. For R console transcripts or R CMD BATCH output files.
+var RConsole = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "RConsole",
+		Aliases:   []string{"rconsole", "rout"},
+		Filenames: []string{"*.Rout"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rd.go
+++ b/lexers/r/rd.go
@@ -1,0 +1,19 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Rd lexer. Lexer for R documentation (Rd) files.
+var Rd = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Rd",
+		Aliases:   []string{"rd"},
+		Filenames: []string{"*.Rd"},
+		MimeTypes: []string{"text/x-r-doc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rebol.go
+++ b/lexers/r/rebol.go
@@ -1,0 +1,37 @@
+package r
+
+import (
+	"regexp"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	rebolAnalyserHeaderRe              = regexp.MustCompile(`^\s*REBOL\s*\[`)
+	rebolAnalyserHeaderPrecedingTextRe = regexp.MustCompile(`\s*REBOL\s*\[`)
+)
+
+// Rebol lexer.
+var Rebol = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "REBOL",
+		Aliases:   []string{"rebol"},
+		Filenames: []string{"*.r", "*.r3", "*.reb"},
+		MimeTypes: []string{"text/x-rebol"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	// Check if code contains REBOL header, then it's probably not R code
+	if rebolAnalyserHeaderRe.MatchString(text) {
+		return 1.0
+	}
+
+	if rebolAnalyserHeaderPrecedingTextRe.MatchString(text) {
+		return 0.5
+	}
+
+	return 0
+}))

--- a/lexers/r/rebol_test.go
+++ b/lexers/r/rebol_test.go
@@ -1,0 +1,40 @@
+package r_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
+)
+
+func TestRebol_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"standard": {
+			Filepath: "testdata/rebol.r",
+			Expected: 1.0,
+		},
+
+		"header preceding text": {
+			Filepath: "testdata/rebol_header_preceding_text.r",
+			Expected: 0.5,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := r.Rebol.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/r/red.go
+++ b/lexers/r/red.go
@@ -1,0 +1,19 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Red lexer. A Red-language <http://www.red-lang.org/> lexer.
+var Red = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Red",
+		Aliases:   []string{"red", "red/system"},
+		Filenames: []string{"*.red", "*.reds"},
+		MimeTypes: []string{"text/x-red", "text/x-red-system"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/redcode.go
+++ b/lexers/r/redcode.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Redcode lexer.
+var Redcode = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Redcode",
+		Aliases:   []string{"redcode"},
+		Filenames: []string{"*.cw"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/resource.go
+++ b/lexers/r/resource.go
@@ -1,0 +1,26 @@
+package r
+
+import (
+	"strings"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Resource lexer. Lexer for ICU Resource bundles
+// <http://userguide.icu-project.org/locale/resources>
+var Resource = internal.Register(MustNewLexer(
+	&Config{
+		Name:    "ResourceBundle",
+		Aliases: []string{"resource", "resourcebundle"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	if strings.HasPrefix(text, "root:table") {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/r/resource_test.go
+++ b/lexers/r/resource_test.go
@@ -1,0 +1,20 @@
+package r_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
+)
+
+func TestResource_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/resource.txt")
+	assert.NoError(t, err)
+
+	analyser, ok := r.Resource.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/r/rhtml.go
+++ b/lexers/r/rhtml.go
@@ -1,0 +1,38 @@
+package r
+
+import (
+	"github.com/alecthomas/chroma"
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/e"
+	"github.com/alecthomas/chroma/lexers/internal"
+	"github.com/alecthomas/chroma/pkg/doctype"
+)
+
+// RHTML lexer. Subclass of the ERB lexer that highlights the unlexed data
+// with the html lexer.
+var RHTML = internal.Register(MustNewLexer(
+	&Config{
+		Name:           "RHTML",
+		Aliases:        []string{"rhtml", "html+erb", "html+ruby"},
+		Filenames:      []string{"*.rhtml"},
+		AliasFilenames: []string{"*.html", "*.htm", "*.xhtml"},
+		MimeTypes:      []string{"text/html+ruby"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	analyser, ok := e.Erb.(chroma.Analyser)
+	if !ok {
+		return 0
+	}
+
+	result := analyser.AnalyseText(text) - 0.01
+
+	if matched, _ := doctype.MatchString(text, "html"); matched {
+		// one more than the XmlErbLexer returns
+		result += 0.5
+	}
+
+	return result
+}))

--- a/lexers/r/rhtml_test.go
+++ b/lexers/r/rhtml_test.go
@@ -1,0 +1,40 @@
+package r_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
+)
+
+func TestRHTML_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"standard": {
+			Filepath: "testdata/rhtml.rhtml",
+			Expected: 0.89,
+		},
+
+		"header preceding text": {
+			Filepath: "testdata/html.rhtml",
+			Expected: 0.49,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := r.RHTML.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/r/ride.go
+++ b/lexers/r/ride.go
@@ -1,0 +1,20 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Ride lexer. For Ride <https://docs.wavesplatform.com/en/ride/about-ride.html>
+// source code.
+var Ride = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Ride",
+		Aliases:   []string{"ride"},
+		Filenames: []string{"*.ride"},
+		MimeTypes: []string{"text/x-ride"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rnccompact.go
+++ b/lexers/r/rnccompact.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RNCCompact lexer. For RelaxNG-compact <http://relaxng.org> syntax.
+var RNCCompact = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Relax-NG Compact",
+		Aliases:   []string{"rnc", "rng-compact"},
+		Filenames: []string{"*.rnc"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/roboconfgraph.go
+++ b/lexers/r/roboconfgraph.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RoboconfGraph lexer for Roboconf <http://roboconf.net/en/roboconf.html> graph files.
+var RoboconfGraph = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Roboconf Graph",
+		Aliases:   []string{"roboconf-graph"},
+		Filenames: []string{"*.graph"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/roboconfinstances.go
+++ b/lexers/r/roboconfinstances.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RoboconfInstances lexer for Roboconf <http://roboconf.net/en/roboconf.html> instances files.
+var RoboconfInstances = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Roboconf Instances",
+		Aliases:   []string{"roboconf-instances"},
+		Filenames: []string{"*.instances"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/robotframework.go
+++ b/lexers/r/robotframework.go
@@ -1,0 +1,19 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RobotFramework lexer for Robot Framework <http://robotframework.org> test data.
+var RobotFramework = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "RobotFramework",
+		Aliases:   []string{"robotframework"},
+		Filenames: []string{"*.robot"},
+		MimeTypes: []string{"text/x-robotframework"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rql.go
+++ b/lexers/r/rql.go
@@ -1,0 +1,19 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RQL lexer for Relation Query Language <http://www.logilab.org/project/rql>
+var RQL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "RQL",
+		Aliases:   []string{"rql"},
+		Filenames: []string{"*.rql"},
+		MimeTypes: []string{"text/x-rql"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/rsl.go
+++ b/lexers/r/rsl.go
@@ -1,0 +1,32 @@
+package r
+
+import (
+	"regexp"
+
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var rslAnalyserRe = regexp.MustCompile(`(?i)scheme\s*.*?=\s*class\s*type`)
+
+// RSL lexer. RSL <http://en.wikipedia.org/wiki/RAISE> is the formal
+// specification language used in RAISE (Rigorous Approach to Industrial
+// Software Engineering) method.
+var RSL = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "RSL",
+		Aliases:   []string{"rsl"},
+		Filenames: []string{"*.rsl"},
+		MimeTypes: []string{"text/rsl"},
+	},
+	Rules{
+		"root": {},
+	},
+).SetAnalyser(func(text string) float32 {
+	// Check for the most common text in the beginning of a RSL file.
+	if rslAnalyserRe.MatchString(text) {
+		return 1.0
+	}
+
+	return 0
+}))

--- a/lexers/r/rsl_test.go
+++ b/lexers/r/rsl_test.go
@@ -1,0 +1,20 @@
+package r_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/r"
+)
+
+func TestRSL_AnalyseText(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/raise.rsl")
+	assert.NoError(t, err)
+
+	analyser, ok := r.RSL.(chroma.Analyser)
+	assert.True(t, ok)
+
+	assert.Equal(t, float32(1.0), analyser.AnalyseText(string(data)))
+}

--- a/lexers/r/rubyirbsession.go
+++ b/lexers/r/rubyirbsession.go
@@ -1,0 +1,18 @@
+package r
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// RubyIRBSession lexer. For Ruby interactive console (**irb**) output.
+var RubyIRBSession = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Ruby irb session",
+		Aliases:   []string{"rbcon", "irb"},
+		MimeTypes: []string{"text/x-ruby-shellsession"},
+	},
+	Rules{
+		"root": {},
+	},
+))

--- a/lexers/r/testdata/html.rhtml
+++ b/lexers/r/testdata/html.rhtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A minimal rhtml example</title>
+</head>
+<body>
+</body>
+</html>

--- a/lexers/r/testdata/ragel.rl
+++ b/lexers/r/testdata/ragel.rl
@@ -1,0 +1,17 @@
+/*
+ * @LANG: indep
+ */
+
+%%{
+	machine any1;
+	main := any;
+}%%
+
+##### INPUT #####
+""
+"x"
+"xx"
+##### OUTPUT #####
+FAIL
+ACCEPT
+FAIL

--- a/lexers/r/testdata/raise.rsl
+++ b/lexers/r/testdata/raise.rsl
@@ -1,0 +1,12 @@
+scheme SET_DATABASE =
+    class
+        type
+            Database = Person-set,
+            Person = Text
+        value
+            empty : Database = {} ,
+            register : Person × Database → Database
+            register(p,db) ≡ db ∪ { p } ,
+            is_in : Person × Database → Bool
+            is_in(p,db) ≡ p ∈ db
+    end

--- a/lexers/r/testdata/rebol.r
+++ b/lexers/r/testdata/rebol.r
@@ -1,0 +1,30 @@
+REBOL [
+	Title: "Resizable Digital Clock"
+	Version: 1.3.3
+	Author: "Carl Sassenrath"
+]
+
+f: layout [
+	origin 0
+	b: banner 140x32 rate 1
+		effect [gradient 0x1 0.0.150 0.0.50]
+		feel [engage: func [f a e] [set-face b now/time]]
+]
+
+resize: does [
+	b/size: max 20x20 min 1000x200 f/size
+	b/font/size: max 24 f/size/y - 40
+	b/text: "Resize Me"
+	b/size/x: 1024 ; for size-text
+	b/size/x: 20 + first size-text b
+	f/size: b/size
+	show f
+]
+
+view/options/new f 'resize
+resize
+insert-event-func [
+	if event/type = 'resize [resize]
+	event
+]
+do-events

--- a/lexers/r/testdata/rebol_header_preceding_text.r
+++ b/lexers/r/testdata/rebol_header_preceding_text.r
@@ -1,0 +1,25 @@
+preface.... everything what is before header is not evaluated
+so this should not be colorized:
+1 + 2
+
+REBOL [] ;<- this is minimal header, everything behind it must be colorized
+
+;## String tests ##
+print "Hello ^"World" ;<- with escaped char
+multiline-string: {
+    bla bla "bla" {bla}
+}
+char-a: #"a"
+escaped-a: #"^(61)"
+new-line: #"^/"
+
+;## Binaries ##
+print decompress 64#{eJzLSM3JyQcABiwCFQUAAAA=}
+;2#{0000 00000} ;<- this one is invalid!
+2#{}
+#{FF00}
+
+;##Date + time ##
+1-Feb-2009
+1-Feb-2009/2:24:46+1:0
+1:0 1:1:1 -0:1.1

--- a/lexers/r/testdata/resource.txt
+++ b/lexers/r/testdata/resource.txt
@@ -1,0 +1,8 @@
+root:table {
+  usage:string { "Usage: genrb [Options] files" }
+  version:int { 122 }
+  errorcodes:array {
+    :string { "Invalid argument" }
+    :string { "File not found" }
+  }
+}

--- a/lexers/r/testdata/rhtml.rhtml
+++ b/lexers/r/testdata/rhtml.rhtml
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A minimal rhtml example</title>
+</head>
+<body>
+	<ul>
+	   <% @products.each do |p| %>
+	      <li><%=  @p.name %></li>
+	   <% end %>
+	</ul>
+</body>
+</html>


### PR DESCRIPTION
Port missing `r` lexers to Chroma.

- RConsole
- Relax-NG Compact
- Ragel Embedded
- Raw token data
- Rd
- REBOL
- Red
- Redcode
- ResourceBundle
- RHTML
- Ride
- Roboconf Graph
- Roboconf Instances
- RobotFramework
- RQL
- RSL

@gandarez As you're the expert in tracking down obscure programming language examples:muscle:, I have a few questions:

- `ResourceBundle`: Used `resource.txt` as test file. Is this the right file format for ICU resource files?
- `Ragel Embedded`: Did not find an example with `@LANG: indep`. Do you know an example?
- `REBOL`: Did not find an example with Rebol header, which is preceded by text. Do you know any?

Closes https://github.com/wakatime/wakatime-cli/issues/217