### PR TITLE
Add basic structure for QVTO lexer

### DIFF
--- a/lexers/q/qvto.go
+++ b/lexers/q/qvto.go
@@ -1,0 +1,18 @@
+package q
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// QVTO lexer. For the QVT Operational Mapping language <http://www.omg.org/spec/QVT/1.1/>.
+var QVTO = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "QVTO",
+		Aliases:   []string{"qvto", "qvt"},
+		Filenames: []string{"*.qvto"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
Port missing `q` lexers to Chroma.

- QVTO [ref](https://github.com/pygments/pygments/blob/master/pygments/lexers/qvt.py#L19)

Lexer `QBasic`, which is mentioned in the original issue, was already implemented.

Closes https://github.com/wakatime/wakatime-cli/issues/216