### PR TITLE
Add Blazor lexer to support matching .razor files

### DIFF
--- a/lexers/b/blazor.go
+++ b/lexers/b/blazor.go
@@ -1,0 +1,18 @@
+package b
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Blazor lexer.
+var Blazor = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "Blazor",
+		Aliases:   []string{"blazor"},
+		Filenames: []string{"*.razor"},
+	},
+	Rules{
+		"root": {},
+	},
+))


### PR DESCRIPTION
This PR adds `Blazor` lexer to support matching `.razor` files.

Closes https://github.com/wakatime/wakatime-cli/issues/156