### PR TITLE
SWIG lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -48,7 +48,7 @@
 | SQL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Sublime Text Config           | Lexer does not exist in pygments    | :heavy_check_mark: |                    |
 | Svelte                        | Lexer does not exist in pygments    | :heavy_check_mark: |                    |
-| SWIG                          |                                     | :heavy_check_mark: | <TODO>             |
+| SWIG                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TypeScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | TypoScript                    | No text analysis exists in pygments | :heavy_check_mark: |                    |
 | QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/s/swig.go
+++ b/lexers/s/swig.go
@@ -1,8 +1,100 @@
 package s
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	swigAnalyserDirectivesRe = regexp.MustCompile(`(?m)^\s*(%[a-z_][a-z0-9_]*)`)
+	swigAnalyserDirectives   = map[string]struct{}{
+		// Most common directives
+		`%apply`:      {},
+		`%define`:     {},
+		`%director`:   {},
+		`%enddef`:     {},
+		`%exception`:  {},
+		`%extend`:     {},
+		`%feature`:    {},
+		`%fragment`:   {},
+		`%ignore`:     {},
+		`%immutable`:  {},
+		`%import`:     {},
+		`%include`:    {},
+		`%inline`:     {},
+		`%insert`:     {},
+		`%module`:     {},
+		`%newobject`:  {},
+		`%nspace`:     {},
+		`%pragma`:     {},
+		`%rename`:     {},
+		`%shared_ptr`: {},
+		`%template`:   {},
+		`%typecheck`:  {},
+		`%typemap`:    {},
+		// Less common directives
+		`%arg`:                  {},
+		`%attribute`:            {},
+		`%bang`:                 {},
+		`%begin`:                {},
+		`%callback`:             {},
+		`%catches`:              {},
+		`%clear`:                {},
+		`%constant`:             {},
+		`%copyctor`:             {},
+		`%csconst`:              {},
+		`%csconstvalue`:         {},
+		`%csenum`:               {},
+		`%csmethodmodifiers`:    {},
+		`%csnothrowexception`:   {},
+		`%default`:              {},
+		`%defaultctor`:          {},
+		`%defaultdtor`:          {},
+		`%defined`:              {},
+		`%delete`:               {},
+		`%delobject`:            {},
+		`%descriptor`:           {},
+		`%exceptionclass`:       {},
+		`%exceptionvar`:         {},
+		`%extend_smart_pointer`: {},
+		`%fragments`:            {},
+		`%header`:               {},
+		`%ifcplusplus`:          {},
+		`%ignorewarn`:           {},
+		`%implicit`:             {},
+		`%implicitconv`:         {},
+		`%init`:                 {},
+		`%javaconst`:            {},
+		`%javaconstvalue`:       {},
+		`%javaenum`:             {},
+		`%javaexception`:        {},
+		`%javamethodmodifiers`:  {},
+		`%kwargs`:               {},
+		`%luacode`:              {},
+		`%mutable`:              {},
+		`%naturalvar`:           {},
+		`%nestedworkaround`:     {},
+		`%perlcode`:             {},
+		`%pythonabc`:            {},
+		`%pythonappend`:         {},
+		`%pythoncallback`:       {},
+		`%pythoncode`:           {},
+		`%pythondynamic`:        {},
+		`%pythonmaybecall`:      {},
+		`%pythonnondynamic`:     {},
+		`%pythonprepend`:        {},
+		`%refobject`:            {},
+		`%shadow`:               {},
+		`%sizeof`:               {},
+		`%trackobjects`:         {},
+		`%types`:                {},
+		`%unrefobject`:          {},
+		`%varargs`:              {},
+		`%warn`:                 {},
+		`%warnfilter`:           {},
+	}
 )
 
 // SWIG lexer.
@@ -18,4 +110,23 @@ var SWIG = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	var result float32
+
+	// Search for SWIG directives, which are conventionally at the beginning of
+	// a line. The probability of them being within a line is low, so let another
+	// lexer win in this case.
+	matches := swigAnalyserDirectivesRe.FindAllString(text, -1)
+
+	for _, m := range matches {
+		if _, ok := swigAnalyserDirectives[m]; ok {
+			result = 0.98
+			break
+		}
+
+		// Fraction higher than MatlabLexer
+		result = 0.91
+	}
+
+	return result
+}))

--- a/lexers/s/swig_test.go
+++ b/lexers/s/swig_test.go
@@ -1,0 +1,39 @@
+package s_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/s"
+)
+
+func TestSWIG_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"default": {
+			Filepath: "testdata/swig.i",
+			Expected: 0.98,
+		},
+		"unknown directive": {
+			Filepath: "testdata/swig_unknown_directive.i",
+			Expected: 0.91,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := s.SWIG.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}

--- a/lexers/s/testdata/swig.i
+++ b/lexers/s/testdata/swig.i
@@ -1,0 +1,9 @@
+%module swig_example
+
+// Add necessary symbols to generated header
+%{
+#include "swig-example.h"
+%}
+
+// Process symbols in header
+%include "swig-example.h"

--- a/lexers/s/testdata/swig_unknown_directive.i
+++ b/lexers/s/testdata/swig_unknown_directive.i
@@ -1,0 +1,1 @@
+%unknown


### PR DESCRIPTION
This PR adds text analysis to the SWIG lexer, as implemented in pygments at https://github.com/pygments/pygments/blob/cfaa45dcc4103da8cf1700fd0d3e5708d894337b/pygments/lexers/c_like.py#L375.

Closes wakatime/wakatime-cli#304