### PR TITLE
VCL lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -54,7 +54,7 @@
 | QBasic                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VB.net                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| VCL                           |                                     | :heavy_check_mark: | <TODO>             |
+| VCL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | Velocity                      |                                     | :heavy_check_mark: | <TODO>             |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | XAML                          | Lexer does not exist in pygments    | :heavy_check_mark: |                    |

--- a/lexers/v/testdata/vcl_preceding_comments.vcl
+++ b/lexers/v/testdata/vcl_preceding_comments.vcl
@@ -1,0 +1,20 @@
+#########################################################################
+# This is an example VCL file for Varnish 4.0.				#
+# From: https://gist.github.com/davidthingsaker/6b0997b641fdd370a395    #
+# LICENSE: If this could help you in any way, you are obliged to use it	#
+# for free with no limitations. 					#
+#########################################################################
+
+
+# Marker to tell the VCL compiler that this VCL has been adapted to the
+# new 4.0 format.
+vcl 4.0;
+
+import std;
+
+# Default backend definition. Set this to point to your content server.
+backend default {
+    .host = "127.0.0.1";
+    .port = "8080";
+}
+

--- a/lexers/v/testdata/vcl_top_line.vcl
+++ b/lexers/v/testdata/vcl_top_line.vcl
@@ -1,0 +1,9 @@
+vcl 4.0;
+
+import std;
+
+# Default backend definition. Set this to point to your content server.
+backend default {
+    .host = "127.0.0.1";
+    .port = "8080";
+}

--- a/lexers/v/vcl.go
+++ b/lexers/v/vcl.go
@@ -1,6 +1,8 @@
 package v
 
 import (
+	"strings"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
 )
@@ -16,4 +18,23 @@ var VCL = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	// If the very first line is 'vcl 4.0;' it's pretty much guaranteed
+	// that this is VCL
+	if strings.HasPrefix(text, "vcl 4.0;") {
+		return 1.0
+	}
+
+	if len(text) > 1000 {
+		text = text[:1000]
+	}
+
+	// Skip over comments and blank lines
+	// This is accurate enough that returning 0.9 is reasonable.
+	// Almost no VCL files start without some comments.
+	if strings.Contains(text, "\nvcl 4.0;") {
+		return 0.9
+	}
+
+	return 0
+}))

--- a/lexers/v/vcl_test.go
+++ b/lexers/v/vcl_test.go
@@ -1,0 +1,39 @@
+package v_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/v"
+)
+
+func TestVCL_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"top line": {
+			Filepath: "testdata/vcl_top_line.vcl",
+			Expected: 1.0,
+		},
+		"with preceding comments": {
+			Filepath: "testdata/vcl_preceding_comments.vcl",
+			Expected: 0.9,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := v.VCL.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds text analysis to VCL lexer, as implemented in pygments at: https://github.com/pygments/pygments/blob/cfaa45dcc4103da8cf1700fd0d3e5708d894337b/pygments/lexers/varnish.py#L30.

Closes wakatime/wakatime-cli#305