### PR TITLE
Velocity lexer text analysis

### DIFF
--- a/lexers/TODO.md
+++ b/lexers/TODO.md
@@ -55,7 +55,7 @@
 | TASM                          |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VB.net                        |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | VCL                           |                                     | :heavy_check_mark: | :heavy_check_mark: |
-| Velocity                      |                                     | :heavy_check_mark: | <TODO>             |
+| Velocity                      |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | verilog                       |                                     | :heavy_check_mark: | :heavy_check_mark: |
 | XAML                          | Lexer does not exist in pygments    | :heavy_check_mark: |                    |
 | XML                           |                                     | :heavy_check_mark: | :heavy_check_mark: |

--- a/lexers/v/testdata/velocity_all.vm
+++ b/lexers/v/testdata/velocity_all.vm
@@ -1,0 +1,27 @@
+#macro (writeTable $productList)
+	#set ($rowCount = 1)
+	#foreach($product in $productList)
+	#if ($rowCount % 2 == 0)
+		#set ($bgcolor = "#FFFFFF")
+	#else
+		#set ($bgcolor = "#CCCCCC")
+	#end
+		<tr>
+			<td bgcolor="$bgcolor">$product.name</td>
+			<td bgcolor="$bgcolor">$product.price</td>
+		</tr>
+		#set ($rowCount = $rowCount + 1)
+	#end
+#end
+
+
+<html>
+	<head>
+		<title>Macros Test</title>
+	</head>
+	<body>
+		<table>
+			#writeTable($products)
+		</table>
+	</body>
+</html>

--- a/lexers/v/testdata/velocity_foreach.vm
+++ b/lexers/v/testdata/velocity_foreach.vm
@@ -1,0 +1,5 @@
+<ul>
+  #foreach( $product in $allProducts )
+    <li>$product</li>
+  #end
+</ul>

--- a/lexers/v/testdata/velocity_if.vm
+++ b/lexers/v/testdata/velocity_if.vm
@@ -1,0 +1,4 @@
+
+#if( $display )
+  <strong>Velocity!</strong>
+#end

--- a/lexers/v/testdata/velocity_macro.vm
+++ b/lexers/v/testdata/velocity_macro.vm
@@ -1,0 +1,4 @@
+
+#macro(getBookListLink, $readingTrackerResult)
+   $readingTrackerResult.getBookListLink()
+#end

--- a/lexers/v/testdata/velocity_reference.vm
+++ b/lexers/v/testdata/velocity_reference.vm
@@ -1,0 +1,2 @@
+
+Hello $name!  Welcome to Velocity!

--- a/lexers/v/velocity.go
+++ b/lexers/v/velocity.go
@@ -1,8 +1,17 @@
 package v
 
 import (
+	"regexp"
+
 	. "github.com/alecthomas/chroma" // nolint
 	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+var (
+	velocityAnalzserMacroRe     = regexp.MustCompile(`(?s)#\{?macro\}?\(.*?\).*?#\{?end\}?`)
+	velocityAnalzserIfRe        = regexp.MustCompile(`(?s)#\{?if\}?\(.+?\).*?#\{?end\}?`)
+	velocityAnalzserForeachRe   = regexp.MustCompile(`(?s)#\{?foreach\}?\(.+?\).*?#\{?end\}?`)
+	velocityAnalzserReferenceRe = regexp.MustCompile(`\$!?\{?[a-zA-Z_]\w*(\([^)]*\))?(\.\w+(\([^)]*\))?)*\}?`)
 )
 
 // Velocity lexer.
@@ -15,4 +24,24 @@ var Velocity = internal.Register(MustNewLexer(
 	Rules{
 		"root": {},
 	},
-))
+).SetAnalyser(func(text string) float32 {
+	var result float64
+
+	if velocityAnalzserMacroRe.MatchString(text) {
+		result += 0.25
+	}
+
+	if velocityAnalzserIfRe.MatchString(text) {
+		result += 0.15
+	}
+
+	if velocityAnalzserForeachRe.MatchString(text) {
+		result += 0.15
+	}
+
+	if velocityAnalzserReferenceRe.MatchString(text) {
+		result += 0.01
+	}
+
+	return float32(result)
+}))

--- a/lexers/v/velocity_test.go
+++ b/lexers/v/velocity_test.go
@@ -1,0 +1,51 @@
+package v_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/alecthomas/chroma"
+	"github.com/alecthomas/chroma/lexers/v"
+)
+
+func TestVelocity_AnalyseText(t *testing.T) {
+	tests := map[string]struct {
+		Filepath string
+		Expected float32
+	}{
+		"macro": {
+			Filepath: "testdata/velocity_macro.vm",
+			Expected: 0.26,
+		},
+		"if": {
+			Filepath: "testdata/velocity_if.vm",
+			Expected: 0.16,
+		},
+		"foreach": {
+			Filepath: "testdata/velocity_foreach.vm",
+			Expected: 0.16,
+		},
+		"reference": {
+			Filepath: "testdata/velocity_reference.vm",
+			Expected: 0.01,
+		},
+		"all": {
+			Filepath: "testdata/velocity_all.vm",
+			Expected: 0.16,
+		},
+	}
+
+	for name, test := range tests {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			data, err := ioutil.ReadFile(test.Filepath)
+			assert.NoError(t, err)
+
+			analyser, ok := v.Velocity.(chroma.Analyser)
+			assert.True(t, ok)
+
+			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds text analysis to `VelocityLexer`, as implemented in pygments at: https://github.com/pygments/pygments/blob/master/pygments/lexers/templates.py#L268.

- Pygments implementation was actually missing support for multi-line directives. This is achieved in go via `(?s)` regex flag. I also opened a PR in pygments to add the respective python flag `re.DOTALL`: https://github.com/pygments/pygments/pull/1776

Closes wakatime/wakatime-cli#306




Closes #11