### PR TITLE
Add new file extensions to Mathematica lexer

### DIFF
--- a/lexers/m/mathematica.go
+++ b/lexers/m/mathematica.go
@@ -10,7 +10,7 @@ var Mathematica = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "Mathematica",
 		Aliases:   []string{"mathematica", "mma", "nb"},
-		Filenames: []string{"*.nb", "*.cdf", "*.nbp", "*.ma"},
+		Filenames: []string{"*.cdf", "*.m", "*.ma", "*.mt", "*.mx", "*.nb", "*.nbp", "*.wl"},
 		MimeTypes: []string{"application/mathematica", "application/vnd.wolfram.mathematica", "application/vnd.wolfram.mathematica.package", "application/vnd.wolfram.cdf"},
 	},
 	Rules{


### PR DESCRIPTION
This PR adds missing new file extensions to Mathematica lexer.

Also added it to Pygments https://github.com/pygments/pygments/pull/1790

Closes https://github.com/wakatime/chroma/issues/113