### PR TITLE
Add priority to R lexer

### DIFF
--- a/lexers/r/r.go
+++ b/lexers/r/r.go
@@ -15,6 +15,8 @@ var R = internal.Register(MustNewLexer(
 		Aliases:   []string{"splus", "s", "r"},
 		Filenames: []string{"*.S", "*.R", "*.r", ".Rhistory", ".Rprofile", ".Renviron"},
 		MimeTypes: []string{"text/S-plus", "text/S", "text/x-r-source", "text/x-r", "text/x-R", "text/x-r-history", "text/x-r-profile"},
+		// Higher priority than Rebol
+		Priority: 0.1,
 	},
 	Rules{
 		"comments": {


### PR DESCRIPTION
This PR adds a priority of 0.1 to `R` lexer, to ensure `*.r` file extension matches `R` instead of `Rebol`. This is needed to ensure wakatime py behavior, also after port of `RebolLexer` from pygments. Problem appeared upon update to latest chroma version in wakatime-cli.

Preparation for https://github.com/wakatime/wakatime-cli/issues/355