### PR TITLE
Limit jasmin lexer to return at maximum 1.0

### DIFF
--- a/lexers/j/jasmin.go
+++ b/lexers/j/jasmin.go
@@ -1,6 +1,7 @@
 package j
 
 import (
+	"math"
 	"regexp"
 
 	. "github.com/alecthomas/chroma" // nolint
@@ -25,7 +26,7 @@ var Jasmin = internal.Register(MustNewLexer(
 		"root": {},
 	},
 ).SetAnalyser(func(text string) float32 {
-	var result float32
+	var result float64
 
 	if jasminAnalyserClassRe.MatchString(text) {
 		result += 0.5
@@ -39,5 +40,5 @@ var Jasmin = internal.Register(MustNewLexer(
 		result += 0.6
 	}
 
-	return result
+	return float32(math.Min(result, float64(1.0)))
 }))


### PR DESCRIPTION
This PR adds `math.Min` to make sure the highest value isn't greater than 1.0.  The [pygments PR](https://github.com/pygments/pygments/pull/1619) has been merged.